### PR TITLE
Finere fix

### DIFF
--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -56,11 +56,6 @@ export default `
   
   .høyrestill {
     float: right;
-    /* 
-      Openhtmltopdf sliter noen ganger med å beregne korrekt bredde for spans dersom man velger "width: auto;". 
-      Dette gjør at span-elementet brekker over i en ekstra linje. Setter width 50% for å unngå dette.
-    */   
-    width: 50%;
-    text-align: right;
+    white-space: normal;
   }
 `;


### PR DESCRIPTION
Fant en finere fix. Skjønner ikke helt hvorfor det feiler i utgangspunktet. Det er ingen grunn til at ordet skal brytes 🤷‍♂️

![image](https://user-images.githubusercontent.com/17828446/109171094-b53b9700-7781-11eb-89b8-b3045c5c0063.png)
