### PR TITLE
Sorterer valgfelt

### DIFF
--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -31,7 +31,7 @@ export const hentAvansertDokumentFelter = async (
                     ${maalform}[defined(markDefs[].flettefeltReferanse)] {
                         "flettefelt": markDefs[].flettefeltReferanse
                     },
-            "delmalValgfelt":  *[_id in ^.${maalform}[].valgReferanse._ref]{
+            "delmalValgfelt":  ^.${maalform}[].valgReferanse | [defined(@)]->{
                     "valgfeltVisningsnavn":visningsnavn,
                     "valgFeltApiNavn": apiNavn,
                     "valgMuligheter":


### PR DESCRIPTION
Henter alle valgfelter riktig sortert innen for sin delmal. Løses ved at alle valgfelt hentes direkte fra sin omsluttende delmal, istedenfor å gjøre subquery.