### PR TITLE
Gjør maks kall-størrelse til 25MB

### DIFF
--- a/.build/nais-dev.yaml
+++ b/.build/nais-dev.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: teamfamilie
   labels:
     team: teamfamilie
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "25M"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+
 spec:
   image: {{ image }}
   team: teamfamilie

--- a/.build/nais-prod.yaml
+++ b/.build/nais-prod.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: teamfamilie
   labels:
     team: teamfamilie
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "25M"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+
 spec:
   image: {{ image }}
   team: teamfamilie


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/CJN0STWB0/p1622719034046900 så tenker jeg det er bedre å være på den sikre siden. 1MB bør være ganske nøyaktig 1000000 tegn, men jeg vet ikke hvor store de avanserte dokumentene til EF kan bli 🤷‍♂️