### PR TITLE
Legg til endepunkt for å hente navn på avanserte dokumenter

### DIFF
--- a/src/server/hentAvansertDokumentNavn.ts
+++ b/src/server/hentAvansertDokumentNavn.ts
@@ -1,0 +1,13 @@
+import { Maalform } from '../typer/sanitygrensesnitt';
+import { client, Datasett } from './sanity/sanityClient';
+import { Feil } from './utils/Feil';
+
+export const hentAvansertDokumentNavn = async (datasett: Datasett): Promise<string> => {
+  const query = `*[_type == "dokumentmal"]{visningsnavn, apiNavn}`;
+
+  return client(datasett)
+    .fetch(query)
+    .catch(error => {
+      throw new Feil(error.message, error.statusCode);
+    });
+};

--- a/src/server/hentAvansertDokumentNavn.ts
+++ b/src/server/hentAvansertDokumentNavn.ts
@@ -1,4 +1,3 @@
-import { Maalform } from '../typer/sanitygrensesnitt';
 import { client, Datasett } from './sanity/sanityClient';
 import { Feil } from './utils/Feil';
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -9,6 +9,7 @@ import hentAvansertDokumentHtml from './hentAvansertDokumentHtml';
 import validerDokumentApiData from './utils/valideringer/validerDokumentApiData';
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import { hentAvansertDokumentFelter, hentFlettefelter } from './hentAvansertDokumentFelter';
+import { hentAvansertDokumentNavn } from './hentAvansertDokumentNavn';
 
 const router = express.Router();
 
@@ -134,6 +135,16 @@ router.get(
     res.send({ data: { dokument: felter, flettefelter }, status: 'SUKSESS' });
   },
 );
+
+router.get('/:datasett/avansert-dokument/navn', async (req: Request, res: Response) => {
+  const datasett = req.params.datasett as Datasett;
+
+  const navn = await hentAvansertDokumentNavn(datasett).catch(err => {
+    res.status(err.code).send(`Henting av avanserte dokumenter feilet: ${err.message}`);
+  });
+
+  res.send({ data: navn, status: 'SUKSESS' });
+});
 
 router.post(
   '/:datasett/avansert-dokument/:maalform/:dokumentApiNavn/pdf',


### PR DESCRIPTION
Brukes i `familie-ef-sak-frontend` for å kunne velge hvilken brevmal man vil bruke. Relevant [Favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5737). 