### PR TITLE
Vis linjeskift i brevet

### DIFF
--- a/src/server/lagManueltBrevHtml.tsx
+++ b/src/server/lagManueltBrevHtml.tsx
@@ -23,13 +23,23 @@ export const lagManueltBrevHtml = (brevMedSignatur: IFritekstbrevMedSignatur) =>
             (brev.brevdato && formaterIsoDato(brev.brevdato)) || dagensDatoFormatert()
           }
         />
-        {brev.avsnitt?.map(avsnitt => (
-          <p>
-            {avsnitt.deloverskrift && <strong>{avsnitt.deloverskrift} </strong>}
-            {avsnitt.deloverskrift && <br />}
-            {avsnitt.innhold}{' '}
-          </p>
-        ))}
+        {brev.avsnitt?.map(avsnitt => {
+          const htmlLinjeskift = new RegExp('\r?\n', 'g');
+
+          return (
+            <p>
+              {avsnitt.deloverskrift && <strong>{avsnitt.deloverskrift} </strong>}
+              {avsnitt.deloverskrift && <br />}
+              {avsnitt.innhold && (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: avsnitt.innhold.replace(htmlLinjeskift, '<br />'),
+                  }}
+                />
+              )}
+            </p>
+          );
+        })}
         <div>
           <p style={{ float: 'left' }}>
             <div>Med vennlig hilsen </div>


### PR DESCRIPTION
Viser linjeskift i brevet. Løsningen har den bieffekten at saksbehandleren kan skrive HTML i brevet, men tenker det går greit da det ikke er sluttbruker som bruker tjenesten.

<img width="1212" alt="Skjermbilde 2021-10-04 kl  14 31 18" src="https://user-images.githubusercontent.com/1413265/135851707-e0314cd0-dc7d-4bd2-88bc-7ed11cf49665.png">
