### PR TITLE
Brevdato i header skal settes til dagens dato direkte i familie-brev

### DIFF
--- a/src/server/hentAvansertDokumentHtml.tsx
+++ b/src/server/hentAvansertDokumentHtml.tsx
@@ -8,6 +8,7 @@ import css from './utils/css';
 import Header from './components/Header';
 import { Maalform } from '../typer/sanitygrensesnitt';
 import { DokumentType } from '../typer/dokumentType';
+import { dagensDatoFormatert } from '../utils/dato';
 
 enum HtmlLang {
   NB = 'nb',
@@ -53,10 +54,7 @@ const hentAvansertDokumentHtml = async (
               navn={dokumentVariabler?.flettefelter?.navn}
               fodselsnummer={dokumentVariabler?.flettefelter?.fodselsnummer}
               apiNavn={dokumentApiNavn}
-              brevOpprettetDato={
-                dokumentVariabler?.flettefelter?.brevOpprettetDato ||
-                dokumentVariabler?.flettefelter?.dato
-              }
+              brevOpprettetDato={[dagensDatoFormatert()]}
             />
             <AvansertDokument
               apiNavn={dokumentApiNavn}


### PR DESCRIPTION
Denne PRen fikser delvis feilen der datoen i vedtaksbrev settes til datoen for "send til beslutter" og ikke  "beslutte vedtak".

Datoen settes nå direkte i `familie-brev` istedenfor å ta det inn som et flettefelt. Det betyr at datoen i brevet blir datoen beslutter sist åpner brevfanen. Datoen kan fortsatt bli hvis beslutter åpner brevfanen en på en gitt dato, men først trykker "godkjenn vedtak" ved en senere anledning (uten å ha vært inne på brevfanen den dagen).

