### PR TITLE
Endre logikk til å se på om søker har utbetaling i perioden eller ikke

### DIFF
--- a/src/ba-sak/formateringer.ts
+++ b/src/ba-sak/formateringer.ts
@@ -10,7 +10,7 @@ import {
 import {
   hentBarnetBarnaDineDittValg,
   hentBarnetBarnaValg,
-  hentDuFårEllerHarRettTilValg,
+  hentDuFårEllerHarRettTilUtvidetValg,
   hentDuOgEllerBarnetBarnaValg,
   hentDuOgEllerBarnFodtValg,
   hentForBarnFodtValg,
@@ -31,8 +31,8 @@ export const formaterValgfelt = (valgfeltBlock: ValgfeltBlock, data: IBegrunnels
       return valgfeltSerializer(valgfeltBlock, hentDuOgEllerBarnFodtValg(data), data);
     case Valgfelttype.FRA_DATO:
       return valgfeltSerializer(valgfeltBlock, hentFraDatoValg(data), data);
-    case Valgfelttype.DU_FÅR_ELLER_HAR_RETT_TIL:
-      return valgfeltSerializer(valgfeltBlock, hentDuFårEllerHarRettTilValg(data), data);
+    case Valgfelttype.DU_FÅR_ELLER_HAR_RETT_TIL_UTVIDET:
+      return valgfeltSerializer(valgfeltBlock, hentDuFårEllerHarRettTilUtvidetValg(data), data);
     default:
       throw new Feil(
         `Ukjent formulering fra santity. Det er ikke laget noen funksjonalitet for ${valgfeltBlock.apiNavn}`,

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -88,10 +88,15 @@ export const hentFraDatoValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
 };
 
 export const hentDuFårEllerHarRettTilValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
-  const søkerBeløp = parseInt(data.belopUtbetaltPaaSokerIPerioden);
-  if (data.antallBarnOppfyllerTriggereOgHarUtbetaling > 0 || søkerBeløp > 0) {
+  if (
+    data.antallBarnOppfyllerTriggereOgHarUtbetaling > 0 ||
+    data.sokerFaarUtbetaltUtvidetIPerioden
+  ) {
     return ValgfeltMuligheter.DU_FÅR;
-  } else if (data.antallBarnOppfyllerTriggereOgHarNullutbetaling > 0 && søkerBeløp == 0) {
+  } else if (
+    data.antallBarnOppfyllerTriggereOgHarNullutbetaling > 0 &&
+    !data.sokerFaarUtbetaltUtvidetIPerioden
+  ) {
     return ValgfeltMuligheter.DU_HAR_RETT_TIL;
   } else {
     throw new Feil(

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -1,5 +1,5 @@
 import { Feil } from '../server/utils/Feil';
-import { IBegrunnelsedata, ValgfeltMuligheter } from './typer';
+import { IBegrunnelsedata, UtvidetPåSøker, ValgfeltMuligheter } from './typer';
 
 export const hentForBarnFodtValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
   if (data.antallBarn === 0) {
@@ -87,21 +87,17 @@ export const hentFraDatoValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
   }
 };
 
-export const hentDuFårEllerHarRettTilValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
-  if (
-    data.antallBarnOppfyllerTriggereOgHarUtbetaling > 0 ||
-    data.sokerFaarUtbetaltUtvidetIPerioden
-  ) {
+export const hentDuFårEllerHarRettTilUtvidetValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
+  if (data.sokerFaarUtbetaltUtvidetIPerioden === UtvidetPåSøker.SØKER_FÅR_UTVIDET) {
     return ValgfeltMuligheter.DU_FÅR;
   } else if (
-    data.antallBarnOppfyllerTriggereOgHarNullutbetaling > 0 &&
-    !data.sokerFaarUtbetaltUtvidetIPerioden
+    data.sokerFaarUtbetaltUtvidetIPerioden === UtvidetPåSøker.SØKER_HAR_RETT_MEN_FÅR_IKKE
   ) {
     return ValgfeltMuligheter.DU_HAR_RETT_TIL;
   } else {
     throw new Feil(
-      `Må ha barn som oppfyller triggere for begrunnelse og har utbetaling eller nullutbetaling for å bruke 
-      'du får eller har rett til' formulering for begrunnelse med apiNavn=${data.apiNavn}`,
+      `Søker må ha rett til utvidet for å bruke 
+      'du får eller har rett til utvidet' formulering for begrunnelse med apiNavn=${data.apiNavn}`,
       400,
     );
   }

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -88,9 +88,10 @@ export const hentFraDatoValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
 };
 
 export const hentDuFårEllerHarRettTilValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
-  if (data.antallBarnOppfyllerTriggereOgHarUtbetaling > 0) {
+  const søkerBeløp = parseInt(data.belopUtbetaltPaaSokerIPerioden);
+  if (data.antallBarnOppfyllerTriggereOgHarUtbetaling > 0 || søkerBeløp > 0) {
     return ValgfeltMuligheter.DU_FÅR;
-  } else if (data.antallBarnOppfyllerTriggereOgHarNullutbetaling > 0) {
+  } else if (data.antallBarnOppfyllerTriggereOgHarNullutbetaling > 0 && søkerBeløp == 0) {
     return ValgfeltMuligheter.DU_HAR_RETT_TIL;
   } else {
     throw new Feil(

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -1,5 +1,5 @@
 import { Feil } from '../server/utils/Feil';
-import { IBegrunnelsedata, UtvidetPåSøker, ValgfeltMuligheter } from './typer';
+import { IBegrunnelsedata, SøkersRettTilUtvidet, ValgfeltMuligheter } from './typer';
 
 export const hentForBarnFodtValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
   if (data.antallBarn === 0) {
@@ -88,11 +88,9 @@ export const hentFraDatoValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
 };
 
 export const hentDuFårEllerHarRettTilUtvidetValg = (data: IBegrunnelsedata): ValgfeltMuligheter => {
-  if (data.sokerFaarUtbetaltUtvidetIPerioden === UtvidetPåSøker.SØKER_FÅR_UTVIDET) {
+  if (data.sokersRettTilUtvidet === SøkersRettTilUtvidet.SØKER_FÅR_UTVIDET) {
     return ValgfeltMuligheter.DU_FÅR;
-  } else if (
-    data.sokerFaarUtbetaltUtvidetIPerioden === UtvidetPåSøker.SØKER_HAR_RETT_MEN_FÅR_IKKE
-  ) {
+  } else if (data.sokersRettTilUtvidet === SøkersRettTilUtvidet.SØKER_HAR_RETT_MEN_FÅR_IKKE) {
     return ValgfeltMuligheter.DU_HAR_RETT_TIL;
   } else {
     throw new Feil(

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -15,7 +15,7 @@ export interface IBegrunnelsedata {
   soknadstidspunkt: string;
   avtaletidspunktDeltBosted: string;
   belop: string;
-  belopUtbetaltPaaSokerIPerioden: string;
+  sokerFaarUtbetaltUtvidetIPerioden: boolean;
 }
 
 export interface IPeriodedata {

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -15,10 +15,10 @@ export interface IBegrunnelsedata {
   soknadstidspunkt: string;
   avtaletidspunktDeltBosted: string;
   belop: string;
-  sokerFaarUtbetaltUtvidetIPerioden: UtvidetPåSøker;
+  sokersRettTilUtvidet: SøkersRettTilUtvidet;
 }
 
-export enum UtvidetPåSøker {
+export enum SøkersRettTilUtvidet {
   SØKER_FÅR_UTVIDET = 'sokerFaarUtvidet',
   SØKER_HAR_RETT_MEN_FÅR_IKKE = 'sokerHarRettMenFaarIkke',
   SØKER_HAR_IKKE_RETT = 'sokerHarIkkeRett',

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -12,6 +12,10 @@ export interface IBegrunnelsedata {
   antallBarnOppfyllerTriggereOgHarNullutbetaling: number;
   maanedOgAarBegrunnelsenGjelderFor: string;
   maalform: Maalform;
+  soknadstidspunkt: string;
+  avtaletidspunktDeltBosted: string;
+  belop: string;
+  belopUtbetaltPaaSokerIPerioden: string;
 }
 
 export interface IPeriodedata {

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -15,7 +15,13 @@ export interface IBegrunnelsedata {
   soknadstidspunkt: string;
   avtaletidspunktDeltBosted: string;
   belop: string;
-  sokerFaarUtbetaltUtvidetIPerioden: boolean;
+  sokerFaarUtbetaltUtvidetIPerioden: UtvidetPåSøker;
+}
+
+export enum UtvidetPåSøker {
+  SØKER_FÅR_UTVIDET = 'sokerFaarUtvidet',
+  SØKER_HAR_RETT_MEN_FÅR_IKKE = 'sokerHarRettMenFaarIkke',
+  SØKER_HAR_IKKE_RETT = 'sokerHarIkkeRett',
 }
 
 export interface IPeriodedata {
@@ -29,7 +35,7 @@ export enum Valgfelttype {
   DU_OG_ELLER_BARNET_BARNA = 'duOgEllerBarnetBarna',
   FOR_BARN_FØDT = 'forBarnFodt',
   FRA_DATO = 'fraDato',
-  DU_FÅR_ELLER_HAR_RETT_TIL = 'duFaarEllerHarRettTil',
+  DU_FÅR_ELLER_HAR_RETT_TIL_UTVIDET = 'duFaarEllerHarRettTilUtvidet',
 }
 
 export enum ValgfeltMuligheter {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8367

Endre logikken for valgfeltet "du får/du har rett til" til å ta basere seg på om søker har utbetaling og/eller rett i perioden eller ikke.

- Søker får utbetalt utvidet? Du får
- Søker får ikke utbetalt utvidet, men har rett (dvs. utvidet overstyrt til 0kr)? Du har rett

Spørsmål: 
- Hvordan kan vi sikre at valgfeltet ikke brukes i en begrunnelse som ikke angår utvidet?

Her er eksempel:
- Periode 1: Ikke rett på utvidet, ikke mulig å velge begrunnelser som skal inneholde dette valgfeltet (og hvis det skulle dukke opp på en begrunnelse de klarer å velge så får de en feil)
- Periode 2: Utvidet er overstyrt til 0kr -> du har rett til
- Periode 3: Barn overstyrt til 0kr, men utvidet blir utbetalt -> du får
- Periode 4: Får utbetalt for barn og utvidet -> du får
![image](https://user-images.githubusercontent.com/25459913/166887168-382f7c21-0b1b-4dd3-b5dd-d92bd6a4e123.png)
![image](https://user-images.githubusercontent.com/25459913/166887248-f4bd3026-9ca7-462d-93bd-019e8fc547e0.png)

Dette skjer når man legger inn valgfeltet i en begrunnelse og den velges i en periode hvor man ikke har rett på utvidet:
![image](https://user-images.githubusercontent.com/25459913/166887868-a0a9ded0-48ad-4419-a9f5-f9c044db7bfa.png)
