### PR TITLE
Oppdaterer block-content-to-react som er deprecated til PortableText

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@navikt/familie-backend": "^7.0.4",
     "@navikt/familie-logging": "^1.0.2",
-    "@sanity/block-content-to-react": "^3.0.0",
+    "@portabletext/react": "^1.0.6",
     "@sanity/client": "^3.3.2",
     "axios": "^0.27.2",
     "concurrently": "^7.0.0",
@@ -36,7 +36,6 @@
     "wait-on": "^6.0.1"
   },
   "devDependencies": {
-    "@types/react": "^16.9.52",
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
@@ -45,6 +44,7 @@
     "@types/express-session": "^1.17.3",
     "@types/jest": "^27.4.1",
     "@types/node": "^18.0.6",
+    "@types/react": "^16.9.52",
     "@types/react-dom": "^16.9.0",
     "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^5.30.5",

--- a/src/ba-sak/begrunnelseSerializer.ts
+++ b/src/ba-sak/begrunnelseSerializer.ts
@@ -13,7 +13,7 @@ import { lagStorForbokstav } from '../utils/strenghåndtering';
 const begrunnelseSerializer = (
   blocks: BegrunnelseBlock[] | Record<string, never>,
   data: BegrunnelseMedData,
-) => {
+): string => {
   if (!Array.isArray(blocks)) {
     throw new Feil(`Fant ikke begrunnelse med apiNavn=${data.apiNavn}`, 404);
   }

--- a/src/ba-sak/formateringer.ts
+++ b/src/ba-sak/formateringer.ts
@@ -94,10 +94,10 @@ const validerFormulering = (
 const settSammenBlokkerTilTekst = (delmalblokk: any[], data: BegrunnelseMedData) =>
   delmalblokk[0].children
     .map((block: any) => {
-      if (block.marks.length > 1) {
-        throw new Feil(`Mer enn ett mark`, 500);
+      if (block.value.length > 1) {
+        throw new Feil(`Mer enn én verdi`, 500);
       }
-      if (block.marks.length === 1) {
+      if (block.value.length === 1) {
         return flettefeltSerializer(delmalblokk, block, data);
       } else {
         return block.text;

--- a/src/server/components/AvansertDokument.tsx
+++ b/src/server/components/AvansertDokument.tsx
@@ -13,8 +13,7 @@ import BlockSerializer from './serializers/BlockSerializer';
 import LenkeSerializer from './serializers/LenkeSerializer';
 import HtmlfeltSerializer from './serializers/HtmlfeltSerializer';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 interface AvansertDokumentProps {
   apiNavn: string;
@@ -48,9 +47,10 @@ function AvansertDokument(avansertDokumentProps: AvansertDokumentProps) {
   }
 
   return (
-    <BlockContent
-      blocks={avansertDokument}
-      serializers={{
+    <PortableText
+      value={avansertDokument}
+      components={{
+        block: BlockSerializer,
         marks: {
           flettefelt: (props: any) =>
             FlettefeltSerializer({
@@ -77,7 +77,6 @@ function AvansertDokument(avansertDokumentProps: AvansertDokumentProps) {
             }),
         },
         types: {
-          block: BlockSerializer,
           undefined: (_: any) => <div />,
           delmalBlock: (props: any) =>
             AvansertDelmalSerializer({

--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -12,8 +12,7 @@ import { DokumentType } from '../../typer/dokumentType';
 import { Feil } from '../utils/Feil';
 import LenkeSerializer from './serializers/LenkeSerializer';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 interface DokumentProps {
   dokumentApiNavn: string;
@@ -46,9 +45,10 @@ const Dokument = (dokumentProps: DokumentProps) => {
   }
 
   return (
-    <BlockContent
-      blocks={dokument}
-      serializers={{
+    <PortableText
+      value={dokument}
+      components={{
+        block: BlockSerializer,
         marks: {
           flettefelt: (props: any) =>
             FlettefeltSerializer({
@@ -66,7 +66,6 @@ const Dokument = (dokumentProps: DokumentProps) => {
               flettefelter: dokumentData?.flettefelter,
               dokumentApiNavn,
             }),
-          block: BlockSerializer,
           perioder: (props: any) =>
             PeriodeSerializer({
               sanityProps: props,

--- a/src/server/components/serializers/AvansertDelmalSerialaizer.tsx
+++ b/src/server/components/serializers/AvansertDelmalSerialaizer.tsx
@@ -13,24 +13,22 @@ interface IAvansertDelmalSerializerProps {
   forelderDokumentApiNavn: string;
 }
 
-const AvansertDelmalSerializer = (props: IAvansertDelmalSerializerProps) => {
+const AvansertDelmalSerializer = (props: IAvansertDelmalSerializerProps): JSX.Element | null => {
   const { sanityProps, delmaler, maalform, datasett, forelderDokumentApiNavn } = props;
-  const { delmalReferanse, erGjentagende, skalAlltidMed } = sanityProps.mark || sanityProps.node;
+  const { delmalReferanse, erGjentagende, skalAlltidMed } = sanityProps.value;
   const delmalApiNavn = delmalReferanse.apiNavn;
 
   validerAvansertDelmal(delmaler, delmalApiNavn, forelderDokumentApiNavn, erGjentagende);
 
   // Hvis ikke konsument har sendt inn delmalen rendrer vi heller ikke denne delen
   if (!skalAlltidMed && (!delmaler || !delmaler[delmalApiNavn])) {
-    return '';
+    return <></>;
   }
   const avanserteDokumentVariabler: IAvansertDokumentVariabler[] | undefined =
     delmaler && delmaler[delmalApiNavn];
 
-  const erInline = !!sanityProps.mark;
-
   return (
-    <div className={`delmal ${erInline ? 'inline' : ''}`}>
+    <div className={'delmal'}>
       {avanserteDokumentVariabler ? (
         avanserteDokumentVariabler.map((variabler, index) => (
           <AvansertDokument

--- a/src/server/components/serializers/BlockSerializer.tsx
+++ b/src/server/components/serializers/BlockSerializer.tsx
@@ -11,10 +11,10 @@ const settTag = (node: any) => {
   return 'div';
 };
 
-const BlockSerializer = (props: any) => {
+const BlockSerializer = (props: any): JSX.Element => {
   const children = rightTrimLastProp(props);
 
-  const Tag = settTag(props.node);
+  const Tag = settTag(props.value);
 
   return (
     <Tag style={{ minHeight: '1rem' }} className={`block`}>

--- a/src/server/components/serializers/DelmalSerializer.tsx
+++ b/src/server/components/serializers/DelmalSerializer.tsx
@@ -4,9 +4,7 @@ import FlettefeltSerializer from './FlettefeltSerializer';
 import BlockSerializer from './BlockSerializer';
 import { Maalform } from '../../../typer/sanitygrensesnitt';
 import LenkeSerializer from './LenkeSerializer';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 interface IDelmalSerializerProps {
   sanityProps: any;
@@ -16,9 +14,7 @@ interface IDelmalSerializerProps {
 
 const DelmalSerializer = (props: IDelmalSerializerProps) => {
   const { sanityProps, delmalData, maalform } = props;
-  // Om delmalen hentes fra en annotering finnes den i sanityProps.mark.
-  // Om den hentes fra en delmalBlock finnes den i sanityProps.node.
-  const { delmalReferanse, skalAlltidMed } = sanityProps.mark || sanityProps.node;
+  const { delmalReferanse, skalAlltidMed } = sanityProps.value;
   const apiNavn = delmalReferanse.apiNavn;
 
   // Hvis ikke konsument har sendt inn delmalen rendrer vi heller ikke denne delen
@@ -28,20 +24,22 @@ const DelmalSerializer = (props: IDelmalSerializerProps) => {
 
   const flettefelter: Flettefelter | undefined = delmalData && delmalData[apiNavn];
 
-  const erInline = !!sanityProps.mark;
-
   return (
-    <div className={`delmal ${erInline ? 'inline' : ''}`}>
-      <BlockContent
-        blocks={delmalReferanse[maalform]}
-        serializers={{
+    <div className={'delmal'}>
+      <PortableText
+        value={delmalReferanse[maalform]}
+        components={{
+          block: BlockSerializer,
           marks: {
             flettefelt: (props: any) =>
-              FlettefeltSerializer({ sanityProps: props, flettefelter, dokumentApiNavn: apiNavn }),
+              FlettefeltSerializer({
+                sanityProps: props,
+                flettefelter,
+                dokumentApiNavn: apiNavn,
+              }),
             lenke: LenkeSerializer,
           },
           types: {
-            block: BlockSerializer,
             undefined: (_: any) => <div />,
           },
         }}

--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -7,12 +7,13 @@ interface IFlettefeltSerializerProps {
   sanityProps: any;
   flettefelter: Flettefelter | undefined;
   dokumentApiNavn: string;
+  erListe?: boolean;
 }
 
 const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
-  const { sanityProps, flettefelter, dokumentApiNavn } = props;
+  const { sanityProps, flettefelter, dokumentApiNavn, erListe } = props;
   const flettefeltNavn = hentFlettefeltNavn(sanityProps);
-  const erListe = hentFlettefeltErListe(sanityProps);
+  const erFlettefeltListe = hentFlettefeltErListe(sanityProps, erListe);
 
   if (!flettefelter) {
     throw new Feil(
@@ -27,11 +28,11 @@ const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
   const høyrestill =
     Array.isArray(props.sanityProps.children) &&
     props.sanityProps.children.length &&
-    props.sanityProps.children[0].props?.node?.mark === 'hoyrestill';
+    props.sanityProps.children[0].props?.markType === 'hoyrestill';
 
-  validerFlettefelt(flettefelt, flettefeltNavn, dokumentApiNavn, erListe);
+  validerFlettefelt(flettefelt, flettefeltNavn, dokumentApiNavn, erFlettefeltListe);
 
-  if (erListe) {
+  if (erFlettefeltListe) {
     return (
       <ul>
         {flettefelt.map((felt, index) => (
@@ -47,20 +48,16 @@ const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
 };
 
 const hentFlettefeltNavn = (sanityProps: any) => {
-  // Om flettefeltet hentes fra en annotering finnes den i props.mark.
-  // Om den hentes fra en block finnes den i props.node.
-  const { flettefeltReferanse, felt } = sanityProps.mark || sanityProps.node;
+  const { flettefeltReferanse, felt } = sanityProps.value;
 
   // Dersom flettefeltet er en referanse ligger det i flettefeltReferanse og må hentes derifra
   const flettefeltNavn = felt ? felt : flettefeltReferanse.felt;
   return flettefeltNavn;
 };
 
-const hentFlettefeltErListe = (sanityProps: any) => {
-  // Om flettefeltet hentes fra en annotering finnes den i props.mark.
-  // Om den hentes fra en block finnes den i props.node.
-  const { flettefeltReferanse } = sanityProps.mark || sanityProps.node;
-  return flettefeltReferanse ? flettefeltReferanse.erListe : !!sanityProps.node;
+const hentFlettefeltErListe = (sanityProps: any, erBegrunnelse?: boolean) => {
+  const { flettefeltReferanse } = sanityProps.value;
+  return !!(flettefeltReferanse?.erListe || erBegrunnelse);
 };
 
 export default FlettefeltSerializer;

--- a/src/server/components/serializers/HtmlfeltSerializer.tsx
+++ b/src/server/components/serializers/HtmlfeltSerializer.tsx
@@ -26,9 +26,7 @@ const HtmlfeltSerializer = (props: IHtmlfeltSerializerProps) => {
 };
 
 const hentFeltnavn = (sanityProps: any) => {
-  // Om flettefeltet hentes fra en annotering finnes den i props.mark.
-  // Om den hentes fra en block finnes den i props.node.
-  const { htmlfeltReferanse, felt } = sanityProps.mark || sanityProps.node;
+  const { htmlfeltReferanse, felt } = sanityProps.value;
 
   // Dersom flettefeltet er en referanse ligger det i flettefeltReferanse og må hentes derifra
   return felt ? felt : htmlfeltReferanse.felt;

--- a/src/server/components/serializers/ListItemSerializer.tsx
+++ b/src/server/components/serializers/ListItemSerializer.tsx
@@ -6,8 +6,7 @@ import { Maalform } from '../../../typer/sanitygrensesnitt';
 import AvansertDelmalSerializer from './AvansertDelmalSerialaizer';
 import FlettefeltSerializer from './FlettefeltSerializer';
 import { DokumentType } from '../../../typer/dokumentType';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 interface IListItemSerializerProps {
   sanityProps: any;
@@ -17,15 +16,15 @@ interface IListItemSerializerProps {
   apiNavn: string;
 }
 
-const ListItemSerializer = (props: IListItemSerializerProps) => {
+const ListItemSerializer = (props: IListItemSerializerProps): JSX.Element | null => {
   const { sanityProps, avanserteDokumentVariabler, maalform, datasett, apiNavn } = props;
   const erDelmal = (markDef: any) => markDef._type === DokumentType.DELMAL;
   const delmalSkalMed = (mark: any): boolean =>
     !mark.skalMedFelt || !!avanserteDokumentVariabler?.delmaler[mark.submal?.id];
 
-  const erKunText = sanityProps.node.markDefs.length === 0;
+  const erKunText = sanityProps.value.markDefs.length === 0;
 
-  const markDefSkalMed = sanityProps.node.markDefs?.reduce(
+  const markDefSkalMed = sanityProps.value.markDefs?.reduce(
     (acc: boolean, markDef: any) => acc || !erDelmal(markDef) || delmalSkalMed(markDef),
     false,
   );
@@ -34,9 +33,9 @@ const ListItemSerializer = (props: IListItemSerializerProps) => {
     return <li>{sanityProps.children}</li>;
   } else if (markDefSkalMed) {
     return (
-      <BlockContent
-        blocks={{ ...sanityProps.node, level: undefined, listItem: undefined }}
-        serializers={{
+      <PortableText
+        value={{ ...sanityProps.value, level: undefined, listItem: undefined }}
+        components={{
           marks: {
             flettefelt: (props: any) =>
               FlettefeltSerializer({
@@ -68,7 +67,7 @@ const ListItemSerializer = (props: IListItemSerializerProps) => {
       />
     );
   } else {
-    return '';
+    return null;
   }
 };
 

--- a/src/server/components/serializers/PeriodeSerializer.tsx
+++ b/src/server/components/serializers/PeriodeSerializer.tsx
@@ -23,8 +23,7 @@ import {
 import { hentBegrunnelseTekstQuery } from '../../../ba-sak/queries';
 import begrunnelseSerializer from '../../../ba-sak/begrunnelseSerializer';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 interface IPeriodeProps {
   sanityProps: any;
@@ -36,8 +35,6 @@ interface IPeriodeProps {
 
 const PeriodeSerializer = (props: IPeriodeProps) => {
   const { perioder, maalform, datasett, forelderApiNavn } = props;
-  // Om delmalen hentes fra en annotering finnes den i props.mark.
-  // Om den hentes fra en delmalBlock finnes den i props.node.
 
   validerPeriode(forelderApiNavn, perioder);
 
@@ -131,29 +128,32 @@ const Periode = (props: { maalform: Maalform; datasett: Datasett; periodedata: I
 
   return (
     <div className={`delmal`}>
-      <BlockContent
-        blocks={periode}
-        serializers={{
+      <PortableText
+        value={periode}
+        components={{
+          block: BlockSerializer,
           marks: {
-            flettefelt: (props: any) =>
+            flettefelt: (sanityProps: any) =>
               FlettefeltSerializer({
-                sanityProps: props,
+                sanityProps: sanityProps,
                 flettefelter: flettefelter as Flettefelter,
                 dokumentApiNavn: periodeApiNavn,
+                erListe: sanityProps?.value?.felt === 'begrunnelser',
               }),
           },
           types: {
-            block: BlockSerializer,
-            flettefelt: (props: any) =>
+            flettefelt: (sanityProps: any) =>
               FlettefeltSerializer({
-                sanityProps: props,
+                sanityProps: sanityProps,
                 flettefelter: flettefelter as Flettefelter,
                 dokumentApiNavn: periodeApiNavn,
+                erListe: sanityProps?.value?.felt === 'begrunnelser',
               }),
             undefined: (_: any) => <div />,
           },
         }}
       />
+
       <div style={{ minHeight: '1rem' }} />
     </div>
   );

--- a/src/server/components/serializers/ValgfeltSerializer.tsx
+++ b/src/server/components/serializers/ValgfeltSerializer.tsx
@@ -14,47 +14,49 @@ interface IValgfeltSerializer {
   forelderDokumentApiNavn: string;
 }
 
-const ValgfeltSerializer = (props: IValgfeltSerializer) => {
+const ValgfeltSerializer = (props: IValgfeltSerializer): JSX.Element => {
   const { sanityProps, valgfelter, maalform, datasett, forelderDokumentApiNavn } = props;
-  const { valgReferanse, erGjentagende, skalAlltidMed } = sanityProps.mark || sanityProps.node;
+  const { valgReferanse, erGjentagende, skalAlltidMed } = sanityProps.value;
   const { apiNavn, valg: muligeValg } = valgReferanse;
 
   validerValgfelt(valgfelter, apiNavn, skalAlltidMed, forelderDokumentApiNavn, erGjentagende);
 
   // Hvis ikke konsument har sendt inn valgfeltet rendrer vi heller ikke denne delen
   if (!valgfelter || !valgfelter[apiNavn]) {
-    return '';
+    return <></>;
   }
 
   const valg: IValg[] = valgfelter[apiNavn];
 
-  const erInline = !!sanityProps.mark;
+  return (
+    <>
+      {valg.map(({ navn, dokumentVariabler }) => {
+        const riktigDokument = muligeValg.find((valg: any) => valg.valgmulighet === navn);
+        const delmalApiNavn = riktigDokument?.delmal?.apiNavn;
+        const delmalApiType = riktigDokument?.delmal?._type;
 
-  return valg.map(({ navn, dokumentVariabler }) => {
-    const riktigDokument = muligeValg.find((valg: any) => valg.valgmulighet === navn);
-    const delmalApiNavn = riktigDokument?.delmal?.apiNavn;
-    const delmalApiType = riktigDokument?.delmal?._type;
-
-    if (delmalApiNavn) {
-      return (
-        <div className={`valgfelt ${erInline ? 'inline' : ''}`}>
-          <AvansertDokument
-            apiNavn={delmalApiNavn}
-            avanserteDokumentVariabler={dokumentVariabler}
-            maalform={maalform}
-            datasett={datasett}
-            dokumentType={delmalApiType}
-          />
-        </div>
-      );
-    } else {
-      throw new Feil(
-        `Fant ikke "${navn}" blant valgene til valgfeltet "${apiNavn}" i "${forelderDokumentApiNavn}".` +
-          `\nMulige valg er ${muligeValg.map((valg: any) => `\n    - "${valg.valgmulighet}"`)}`,
-        404,
-      );
-    }
-  });
+        if (delmalApiNavn) {
+          return (
+            <div className={'valgfelt'}>
+              <AvansertDokument
+                apiNavn={delmalApiNavn}
+                avanserteDokumentVariabler={dokumentVariabler}
+                maalform={maalform}
+                datasett={datasett}
+                dokumentType={delmalApiType}
+              />
+            </div>
+          );
+        } else {
+          throw new Feil(
+            `Fant ikke "${navn}" blant valgene til valgfeltet "${apiNavn}" i "${forelderDokumentApiNavn}".` +
+              `\nMulige valg er ${muligeValg.map((valg: any) => `\n    - "${valg.valgmulighet}"`)}`,
+            404,
+          );
+        }
+      })}
+    </>
+  );
 };
 
 export default ValgfeltSerializer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,6 +1495,26 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@portabletext/react@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@portabletext/react/-/react-1.0.6.tgz#508ede0b165a3705db6907a94ff67c791d9ab432"
+  integrity sha512-j6BprLiwFz3zr1Lo6BxM2sQ1b3g1JIjGwePeuxqSfbBiEYbGXn2izEckMJ02hSa1f7+RCEUJ+Bojvtzz6BBUaw==
+  dependencies:
+    "@portabletext/toolkit" "^1.0.5"
+    "@portabletext/types" "^1.0.3"
+
+"@portabletext/toolkit@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@portabletext/toolkit/-/toolkit-1.0.5.tgz#2bbcc527a6dd1f6594fb538ff9670a9958147197"
+  integrity sha512-kwVOfVoquufDQNmzzhGxji9A+/T+dhLKKOHEHldM1kMUoNzY6wwrt5H/Plnw4xbdE780kkwqJqHxjxoSYr706A==
+  dependencies:
+    "@portabletext/types" "^1.0.3"
+
+"@portabletext/types@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@portabletext/types/-/types-1.0.3.tgz#b23f832ae5331c1d864195a95eba34abf340597e"
+  integrity sha512-SDDsdury2SaTI2D5Ea6o+Y39SSZMYHRMWJHxkxYl3yzFP0n/0EknOhoXcoaV+bxGr2dTTqZi2TOEj+uWYuavSw==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -1537,24 +1557,6 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz#7f698254aadf921e48dda8c0a6b304026b8a9323"
   integrity sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==
 
-"@sanity/block-content-to-hyperscript@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz#a8437b608daac9b7cc4124c490d345fa84d4a267"
-  integrity sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==
-  dependencies:
-    "@sanity/generate-help-url" "^0.140.0"
-    "@sanity/image-url" "^0.140.15"
-    hyperscript "^2.0.2"
-    object-assign "^4.1.1"
-
-"@sanity/block-content-to-react@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz#1deac74763540fdf61b14ad52fb1a01b35d60453"
-  integrity sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==
-  dependencies:
-    "@sanity/block-content-to-hyperscript" "^3.0.0"
-    prop-types "^15.6.2"
-
 "@sanity/client@^3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.3.2.tgz#54d892664ee492c894b73e6f85bcf7054d6b281c"
@@ -1575,20 +1577,10 @@
     event-source-polyfill "1.0.25"
     eventsource "^2.0.2"
 
-"@sanity/generate-help-url@^0.140.0":
-  version "0.140.0"
-  resolved "https://registry.yarnpkg.com/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz#f60ab75be5fdc346b9f0d1c2a0858aa3c2870109"
-  integrity sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw==
-
 "@sanity/generate-help-url@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@sanity/generate-help-url/-/generate-help-url-3.0.0.tgz#60e9cba61b82103ea3761730a53cd9310b98892d"
   integrity sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA==
-
-"@sanity/image-url@^0.140.15":
-  version "0.140.22"
-  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-0.140.22.tgz#7a65f56bb751f7b1c5dfacfadd34ee10fc4f0fde"
-  integrity sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==
 
 "@sanity/timed-out@^4.0.2":
   version "4.0.2"
@@ -3240,11 +3232,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browser-split@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/browser-split/-/browser-split-0.0.0.tgz#41419caef769755929dd518967d3eec0a6262771"
-  integrity sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E=
-
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.17.5, browserslist@^4.18.1, browserslist@^4.19.1:
   version "4.19.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.3.tgz#29b7caad327ecf2859485f696f9604214bedd383"
@@ -3448,13 +3435,6 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
-
-class-list@~0.1.0, class-list@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/class-list/-/class-list-0.1.1.tgz#9b9745192c4179b5da0a0d7633658e3c70d796cb"
-  integrity sha1-m5dFGSxBebXaCg12M2WOPHDXlss=
-  dependencies:
-    indexof "0.0.1"
 
 clean-css@^5.2.2:
   version "5.2.4"
@@ -5801,13 +5781,6 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-element@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/html-element/-/html-element-2.3.1.tgz#5feb23dd5226467ef8c2faec51a5bf29c4ef5440"
-  integrity sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==
-  dependencies:
-    class-list "~0.1.1"
-
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -5966,15 +5939,6 @@ husky@^7.0.0:
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
-hyperscript@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hyperscript/-/hyperscript-2.0.2.tgz#3839cba45554bdfe27bb81c2142d1684f8135af5"
-  integrity sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=
-  dependencies:
-    browser-split "0.0.0"
-    class-list "~0.1.0"
-    html-element "^2.0.0"
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -6051,11 +6015,6 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -8628,7 +8587,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
Migrerer fra `@sanity/block-content-to-react` til `@portabletext/react` etter guide her: https://github.com/portabletext/react-portabletext/blob/main/MIGRATING.md

Prøvde å lage noen tester som bekrefter at HTMLen som genereres er lik, men det ser ut som den nye versjonen wrapper komponentene i færre `div`er uten at det utgjør noen forskjell for hvordan det blir visuelt. Dette gjør det vanskelig å teste på noen annen måte enn med øyenene. 

### HTML
**Før**
![image](https://user-images.githubusercontent.com/17828446/182145566-7dd4828c-c998-4271-9064-47829cc29a9f.png)

**Nå**
![image](https://user-images.githubusercontent.com/17828446/182145595-ac1d5c3c-9ba7-45d8-8031-c67c37f65196.png)


### Delmal
**Før**
![image](https://user-images.githubusercontent.com/17828446/182144550-c2b2906a-a6a4-4d31-87b8-1654a4b9db3f.png)

**Nå**
![image](https://user-images.githubusercontent.com/17828446/182144397-efdbf617-92f1-4c62-86c1-07f468a1d1e6.png)


### Avansert delmal
**Før**
![image](https://user-images.githubusercontent.com/17828446/182144659-6a274cde-d734-4d08-8348-35d29febc31d.png)

**Nå**
![image](https://user-images.githubusercontent.com/17828446/182144337-a61a8b50-2b32-4aa9-b621-7daea22737e0.png)

