### PR TITLE
Legg til støtte for deg og eller barnet barna formulering

### DIFF
--- a/src/ba-sak/formateringer.ts
+++ b/src/ba-sak/formateringer.ts
@@ -12,10 +12,10 @@ import {
   hentBarnetBarnaDineDittValg,
   hentBarnetBarnaValg,
   hentDuFårEllerHarRettTilUtvidetValg,
-  hentDuOgEllerBarnetBarnaValg,
   hentDuOgEllerBarnFodtValg,
   hentForBarnFodtValg,
   hentFraDatoValg,
+  hentSøkerOgEllerBarnetBarnaValg,
   søkersAktivitetValg,
 } from './formateringsvalg';
 
@@ -24,7 +24,8 @@ export const formaterValgfelt = (valgfeltBlock: ValgfeltBlock, data: Begrunnelse
     case Valgfelttype.FOR_BARN_FØDT:
       return valgfeltSerializer(valgfeltBlock, hentForBarnFodtValg(data), data);
     case Valgfelttype.DU_OG_ELLER_BARNET_BARNA:
-      return valgfeltSerializer(valgfeltBlock, hentDuOgEllerBarnetBarnaValg(data), data);
+    case Valgfelttype.DEG_OG_ELLER_BARNET_BARNA:
+      return valgfeltSerializer(valgfeltBlock, hentSøkerOgEllerBarnetBarnaValg(data), data);
     case Valgfelttype.BARNET_BARNA:
       return valgfeltSerializer(valgfeltBlock, hentBarnetBarnaValg(data), data);
     case Valgfelttype.BARNET_BARNA_DINE_DITT:

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -16,8 +16,8 @@ export const hentForBarnFodtValg = (data: BegrunnelseMedData): ValgfeltMulighete
   }
 };
 
-export const hentDuOgEllerBarnetBarnaValg = (data: BegrunnelseMedData): ValgfeltMuligheter => {
-  const valgfeltNavn = `'du og/eller barnet/barna'`;
+export const hentSøkerOgEllerBarnetBarnaValg = (data: BegrunnelseMedData): ValgfeltMuligheter => {
+  const valgfeltNavn = `'du/deg og/eller barnet/barna'`;
 
   if (data.type === Begrunnelsetype.EØS_BEGRUNNELSE) {
     throw lagFeilStøttesIkkeForEØS(valgfeltNavn, data);

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -54,6 +54,7 @@ export enum Valgfelttype {
   BARNET_BARNA_DINE_DITT = 'barnetBarnaDineDitt',
   DU_OG_ELLER_BARN_FØDT = 'duOgEllerBarnFodt',
   DU_OG_ELLER_BARNET_BARNA = 'duOgEllerBarnetBarna',
+  DEG_OG_ELLER_BARNET_BARNA = 'degOgEllerBarnetBarna',
   FOR_BARN_FØDT = 'forBarnFodt',
   FRA_DATO = 'fraDato',
   DU_FÅR_ELLER_HAR_RETT_TIL_UTVIDET = 'duFaarEllerHarRettTilUtvidet',


### PR DESCRIPTION
Favro: [Tea-9251](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9251)

Begrunnelse for eøs opphør [5. Separasjonsavtalen gjelder ikke](https://familie-brev.sanity.studio/ba-brev/desk/begrunnelse;eos;opphor;1b29f277-28f9-40cd-804a-9f745ff8fab8) krever støtte for å ha formuleringen "deg og eller barnet/barna". 

Legger til støtte for det
