### PR TITLE
Feature/søkers aktivitetsland

### DIFF
--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -142,44 +142,34 @@ export const søkersAktivitetValg = (data: BegrunnelseMedData): ValgfeltMulighet
     throw lagFeilStøttesKunForEØS(valgfeltNavn, data);
   }
 
-  if (
-    [SøkersAktivitet.ARBEIDER_I_NORGE, SøkersAktivitet.SELVSTENDIG_NÆRINGSDRIVENDE].includes(
-      data.sokersAktivitet,
-    )
-  ) {
-    return ValgfeltMuligheter.ARBEIDER_I_NORGE;
-  } else if (
-    [
-      SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NORGE,
-      SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN,
-      SøkersAktivitet.MOTTAR_PENSJON_FRA_NORGE,
-    ].includes(data.sokersAktivitet)
-  ) {
-    return ValgfeltMuligheter.UTBETALING_FRA_NAV;
-  } else if ([SøkersAktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE].includes(data.sokersAktivitet)) {
-    return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
-  } else if (data.sokersAktivitet === SøkersAktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP) {
-    return ValgfeltMuligheter.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP;
-  } else if (data.sokersAktivitet === SøkersAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL) {
-    return ValgfeltMuligheter.ARBEIDER_PÅ_NORSK_SOKKEL;
-  } else if (data.sokersAktivitet === SøkersAktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP) {
-    return ValgfeltMuligheter.ARBEIDER_FOR_NORSK_FLYSELSKAP;
-  } else if (data.sokersAktivitet === SøkersAktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON) {
-    return ValgfeltMuligheter.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
-  } else if (
-    [
-      SøkersAktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
-      SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
-      SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
-    ].includes(data.sokersAktivitet)
-  ) {
-    return ValgfeltMuligheter.UTBETALING_FRA_NAV_I_UTLANDET;
-  } else {
-    throw new Feil(
-      `Ingen valg for søkers aktivitet="${data.sokersAktivitet}" ved bruk av
+  switch (data.sokersAktivitet) {
+    case SøkersAktivitet.ARBEIDER_I_NORGE:
+    case SøkersAktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
+      return ValgfeltMuligheter.ARBEIDER_I_NORGE;
+    case SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NORGE:
+    case SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN:
+    case SøkersAktivitet.MOTTAR_PENSJON:
+      return ValgfeltMuligheter.UTBETALING_FRA_NAV;
+    case SøkersAktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
+      return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
+    case SøkersAktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:
+      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP;
+    case SøkersAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL:
+      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSK_SOKKEL;
+    case SøkersAktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP:
+      return ValgfeltMuligheter.ARBEIDER_FOR_NORSK_FLYSELSKAP;
+    case SøkersAktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON:
+      return ValgfeltMuligheter.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
+    case SøkersAktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+    case SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+    case SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+      return ValgfeltMuligheter.UTBETALING_FRA_NAV_I_UTLANDET;
+    default:
+      throw new Feil(
+        `Ingen valg for søkers aktivitet="${data.sokersAktivitet}" ved bruk av
       ${valgfeltNavn} formulering for begrunnelse med apiNavn=${data.apiNavn}`,
-      400,
-    );
+        400,
+      );
   }
 };
 

--- a/src/ba-sak/formateringsvalg.ts
+++ b/src/ba-sak/formateringsvalg.ts
@@ -144,12 +144,26 @@ export const søkersAktivitetValg = (data: BegrunnelseMedData): ValgfeltMulighet
 
   switch (data.sokersAktivitet) {
     case SøkersAktivitet.ARBEIDER_I_NORGE:
+    case SøkersAktivitet.ARBEIDER:
     case SøkersAktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
-      return ValgfeltMuligheter.ARBEIDER_I_NORGE;
+      if (data.sokersAktivitetsland === undefined) {
+        return ValgfeltMuligheter.ARBEIDER_I_NORGE;
+      } else {
+        return ValgfeltMuligheter.ARBEIDER;
+      }
+
     case SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NORGE:
     case SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN:
+    case SøkersAktivitet.MOTTAR_PENSJON_FRA_NORGE:
+    case SøkersAktivitet.MOTTAR_UFØRETRYGD:
+    case SøkersAktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN:
     case SøkersAktivitet.MOTTAR_PENSJON:
-      return ValgfeltMuligheter.UTBETALING_FRA_NAV;
+      if (data.sokersAktivitetsland === undefined) {
+        return ValgfeltMuligheter.UTBETALING_FRA_NAV;
+      } else {
+        return ValgfeltMuligheter.FÅR_PENGER_SOM_ERSTATTER_LØNN;
+      }
+
     case SøkersAktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
       return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
     case SøkersAktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:

--- a/src/ba-sak/typer.ts
+++ b/src/ba-sak/typer.ts
@@ -26,7 +26,8 @@ export interface IEØSBegrunnelsedata {
   apiNavn: string;
   sokersAktivitet: SøkersAktivitet;
   annenForeldersAktivitet: AnnenForeldersAktivitet;
-  annenForeldersAktivitetsland: string;
+  annenForeldersAktivitetsland?: string;
+  sokersAktivitetsland?: string;
   barnetsBostedsland: string;
   barnasFodselsdatoer: string;
   antallBarn: number;
@@ -78,8 +79,10 @@ export enum ValgfeltMuligheter {
   DU_FÅR = 'duFaar',
   DU_HAR_RETT_TIL = 'duHarRettTil',
 
-  ARBEIDER_I_NORGE = 'arbeiderINorge',
-  UTBETALING_FRA_NAV = 'utbetalingFraNav',
+  ARBEIDER_I_NORGE = 'arbeiderINorge', // TODO DEPRECATED skal bruke ARBEIDER
+  ARBEIDER = 'arbeider',
+  UTBETALING_FRA_NAV = 'utbetalingFraNav', // TODO DEPRECATED skal bruke FÅR_PENGER_SOM_ERSTATTER_LØNN
+  FÅR_PENGER_SOM_ERSTATTER_LØNN = 'faarPengerSomErstatterLonn',
   UTSENDT_ARBEIDSTAKER_FRA_NORGE = 'utsendtArbeidstakerFraNorge',
   ARBEIDER_PÅ_NORSKREGISTRERT_SKIP = 'arbeiderPaNorskregistrertSkip',
   ARBEIDER_PÅ_NORSK_SOKKEL = 'arbeiderPaNorskSokkel',
@@ -142,12 +145,26 @@ export enum Begrunnelsetype {
 }
 
 export enum SøkersAktivitet {
+  // Deprecated: Skal bruke ARBEIDER"
   ARBEIDER_I_NORGE = 'ARBEIDER_I_NORGE',
+  ARBEIDER = 'ARBEIDER',
+
   SELVSTENDIG_NÆRINGSDRIVENDE = 'SELVSTENDIG_NÆRINGSDRIVENDE',
+
+  // Deprecated: Skal bruke MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN"
   MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN = 'MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN',
+  MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN = 'MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN',
+
   UTSENDT_ARBEIDSTAKER_FRA_NORGE = 'UTSENDT_ARBEIDSTAKER_FRA_NORGE',
+
+  // Deprecated: Skal bruke MOTTAR_UFØRETRYGD"
   MOTTAR_UFØRETRYGD_FRA_NORGE = 'MOTTAR_UFØRETRYGD_FRA_NORGE',
+  MOTTAR_UFØRETRYGD = 'MOTTAR_UFØRETRYGD',
+
+  // Deprecated: Skal bruke MOTTAR_PENSJON"
   MOTTAR_PENSJON_FRA_NORGE = 'MOTTAR_PENSJON_FRA_NORGE',
+  MOTTAR_PENSJON = 'MOTTAR_PENSJON',
+
   ARBEIDER_PÅ_NORSKREGISTRERT_SKIP = 'ARBEIDER_PÅ_NORSKREGISTRERT_SKIP',
   ARBEIDER_PÅ_NORSK_SOKKEL = 'ARBEIDER_PÅ_NORSK_SOKKEL',
   ARBEIDER_FOR_ET_NORSK_FLYSELSKAP = 'ARBEIDER_FOR_ET_NORSK_FLYSELSKAP',


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9195

Vi skal støtte ganske mye av det vi støtter for primærland allerede for sekundærland også. Endrer så vi ikke antar at søkers aktivitetsland er norge. Denne endringen er bakoverkompatibel, men krever at vi fjerner enumvariabler som er deprecated når dette er fikset i ba-sak også 

Er nok lettest å lese kommit for kommit