### PR TITLE
Fjerne duplikate begrunnelser

### DIFF
--- a/src/server/components/serializers/PeriodeSerializer.tsx
+++ b/src/server/components/serializers/PeriodeSerializer.tsx
@@ -98,7 +98,7 @@ const Periode = (props: { maalform: Maalform; datasett: Datasett; periodedata: I
   };
 
   const byggBegrunnelser = (begrunnelser: Begrunnelse[] | Flettefelt): string[] => {
-    return begrunnelser.map((begrunnelse: Begrunnelse | string) => {
+    const bygdeBegrunnelser = begrunnelser.map((begrunnelse: Begrunnelse | string) => {
       if (typeof begrunnelse === 'string') {
         return begrunnelse;
       } else if (begrunnelse.type === Begrunnelsetype.FRITEKST) {
@@ -111,6 +111,9 @@ const Periode = (props: { maalform: Maalform; datasett: Datasett; periodedata: I
         return byggBegrunnelse(begrunnelse);
       }
     });
+
+    // Fjerner duplikate begrunnelser
+    return [...new Set(bygdeBegrunnelser)];
   };
 
   const flettefelter = { ...periodedata };


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Gjør om listen med begrunnelser fra liste til sett for å fjerne identiske begrunnelser.
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10271

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Denne endringen gjør at identiske begrunnelsen i en periode fjernes når man viser brev (pdf). Det er laget en egen PR for å fjerne duplikater i forhåndsvisningen i familie-ba-sak. Se egen PR (https://github.com/navikt/familie-ba-sak/pull/3103).

### Bilder 
| Før | Etter    | 
| :---:   | :---: | 
| <img width="740" alt="image" src="https://user-images.githubusercontent.com/46678893/204304291-f7bc490c-8d5d-4b04-b3b2-a5957635f370.png"> | <img width="408" alt="image" src="https://user-images.githubusercontent.com/46678893/204304387-e8cd853d-a49e-4752-a78c-2422d6059837.png"> | 