### PR TITLE
Fikser en bug i hentDelmalQuery:

### DIFF
--- a/src/server/sanity/Queries.ts
+++ b/src/server/sanity/Queries.ts
@@ -29,28 +29,18 @@ export const hentDokumentQuery = (
 *[_type == "${dokumentType}" && apiNavn == "${dokumentApiNavn}"][0]
   {..., ${maalform}[]
     { ...,
-      _type == "block"=> {..., markDefs[]{
-        ...,
-        flettefeltReferanse->
-        }
-      },
+      _type == "block" => {..., markDefs[]{..., flettefeltReferanse->}},
       _type == "flettefelt" => {..., flettefeltReferanse->},
-      _type == "delmal" => {..., 
-        delmalReferanse->${hentDelmalQuery(maalform)}
-      },
+      _type == "delmal" => {..., delmalReferanse->${hentDelmalQuery(maalform)}},
     }
   }
  `;
 
-export const hentDelmalQuery = (maalform: string) =>
-  `{
-    ..., ${maalform}[]{
-      ..., 
-      _type == "block"=> {..., markDefs[]{
-          ...,
-          flettefeltReferanse->
-        },
+export const hentDelmalQuery = (maalform: string) => `
+  {..., ${maalform}[]
+    { ..., 
+      _type == "block" => {..., markDefs[]{..., flettefeltReferanse->}},
       _type == "flettefelt" => {..., flettefeltReferanse->}
-      },
     }
-  }`;
+  }
+ `;


### PR DESCRIPTION
Pga. ulik plassering av curly brackets ble ikke flettefelter innenfor en delmal håndtert på samme måte som utenfor. Har i tillegg til å rette feilen reformatert koden noe, for enklere sammenligning med håndteringen av flettefeltreferanser ovenfor.