### PR TITLE
Hent beskrivelsen til valgfelt med brevstruktur

### DIFF
--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -35,6 +35,7 @@ export const hentAvansertDokumentFelter = async (
             "delmalValgfelt":  ^.${maalform}[].valgReferanse | [defined(@)]->{
                     "valgfeltVisningsnavn":visningsnavn,
                     "valgFeltApiNavn": apiNavn,
+                    "valgfeltBeskrivelse": beskrivelse,
                     "valgMuligheter":
                         valg[]{
                             valgmulighet,


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
I EF-sak har vi behov for å kunne legge til ekstra beskrivelse av valgfelter og flettefelt for å kunne forklare automatiske verdier og slippe lange titler med informasjon i parantes. 

### Hvordan påvirker dette andre?
Beskrivelse vil kun hentes om en verdi er gitt (TLDR ingen påvirkning). 

Henger sammen med PR [364](https://github.com/navikt/familie-sanity-brev/pull/364) i familie-sanity-brev