### PR TITLE
Fritekstområde sanitybrev

### DIFF
--- a/src/server/components/AvansertDokument.tsx
+++ b/src/server/components/AvansertDokument.tsx
@@ -15,6 +15,7 @@ import LenkeSerializer from './serializers/LenkeSerializer';
 import HtmlfeltSerializer from './serializers/HtmlfeltSerializer';
 
 import { PortableText } from '@portabletext/react';
+import { FritekstområdeSerializer } from './serializers/FritekstområdeSerializer';
 
 interface AvansertDokumentProps {
   apiNavn: string;
@@ -100,6 +101,11 @@ function AvansertDokument(avansertDokumentProps: AvansertDokumentProps) {
               sanityProps: props,
               htmlfelter: avanserteDokumentVariabler?.htmlfelter,
               dokumentApiNavn: apiNavn,
+            }),
+          fritekstområde: (props: any) =>
+            FritekstområdeSerializer({
+              sanityProps: props,
+              fritekstområder: avanserteDokumentVariabler?.fritekstområder,
             }),
         },
         listItem: (props: any) =>

--- a/src/server/components/serializers/FritekstområdeSerializer.tsx
+++ b/src/server/components/serializers/FritekstområdeSerializer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { IFritekstområder } from '../../../typer/dokumentApi';
+
+interface IFritekstområdeSerializerProps {
+  sanityProps: any;
+  fritekstområder?: IFritekstområder;
+}
+
+export const FritekstområdeSerializer = (props: IFritekstområdeSerializerProps) => {
+  const { sanityProps, fritekstområder } = props;
+
+  if (!fritekstområder) return null;
+
+  const uuid = sanityProps.value._key;
+  const avsnitt = fritekstområder[uuid];
+
+  return (
+    <div>
+      {avsnitt.map((avsnitt, indeks) => (
+        <div key={uuid + indeks}>{avsnitt.innhold}</div>
+      ))}
+    </div>
+  );
+};

--- a/src/server/components/serializers/FritekstområdeSerializer.tsx
+++ b/src/server/components/serializers/FritekstområdeSerializer.tsx
@@ -16,8 +16,12 @@ export const FritekstområdeSerializer = (props: IFritekstområdeSerializerProps
 
   return (
     <div>
-      {avsnitt.map((avsnitt, indeks) => (
-        <div key={uuid + indeks}>{avsnitt.innhold}</div>
+      {avsnitt.map((avsnitt, index) => (
+        <p key={index}>
+          {avsnitt.deloverskrift && <strong>{avsnitt.deloverskrift} </strong>}
+          {avsnitt.deloverskrift && <br />}
+          {avsnitt.innhold && <span style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</span>}
+        </p>
       ))}
     </div>
   );

--- a/src/server/components/serializers/FritekstområdeSerializer.tsx
+++ b/src/server/components/serializers/FritekstområdeSerializer.tsx
@@ -16,13 +16,14 @@ export const FritekstområdeSerializer = (props: IFritekstområdeSerializerProps
 
   return (
     <div>
-      {avsnitt.map((avsnitt, index) => (
-        <p key={index}>
-          {avsnitt.deloverskrift && <strong>{avsnitt.deloverskrift} </strong>}
-          {avsnitt.deloverskrift && <br />}
-          {avsnitt.innhold && <span style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</span>}
-        </p>
-      ))}
+      {avsnitt &&
+        avsnitt.map((avsnitt, index) => (
+          <p key={index}>
+            {avsnitt.deloverskrift && <strong>{avsnitt.deloverskrift} </strong>}
+            {avsnitt.deloverskrift && <br />}
+            {avsnitt.innhold && <span style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</span>}
+          </p>
+        ))}
     </div>
   );
 };

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -46,10 +46,10 @@ export const hentAvansertDokumentFelter = async (
                         }
             }
         },
-        "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "Fritekstområde" ] | { 
+        "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
             _type,
             "blokk": select(
-                _type == "Fritekstområde" => {"id": uuid},
+                _type == "fritekstområde" => { "id": _key },
                 defined(delmalReferanse) => delmalReferanse->{
                   "delmalApiNavn": apiNavn,
                   "delmalNavn": visningsnavn,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -48,7 +48,7 @@ export const hentAvansertDokumentFelter = async (
         },
         "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
             _type,
-            "blokk": select(
+            "innhold": select(
                 _type == "fritekstområde" => { "id": _key },
                 defined(delmalReferanse) => delmalReferanse->{
                   "delmalApiNavn": apiNavn,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -45,6 +45,34 @@ export const hentAvansertDokumentFelter = async (
                             }  
                         }
             }
+        },
+        "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "Fritekstområde" ] | { 
+            _type,
+            "blokk": select(
+                _type == "Fritekstområde" => {"id": uuid},
+                defined(delmalReferanse) => delmalReferanse->{
+                  "delmalApiNavn": apiNavn,
+                  "delmalNavn": visningsnavn,
+                  gruppeVisningsnavn,
+                  "delmalFlettefelter": 
+                          ${maalform}[defined(markDefs[].flettefeltReferanse)] {
+                              "flettefelt": markDefs[].flettefeltReferanse
+                          },
+                  "delmalValgfelt":  ^.${maalform}[].valgReferanse | [defined(@)]->{
+                          "valgfeltVisningsnavn":visningsnavn,
+                          "valgFeltApiNavn": apiNavn,
+                          "valgfeltBeskrivelse": beskrivelse,
+                          "valgMuligheter":
+                              valg[]{
+                                  valgmulighet,
+                                  "visningsnavnValgmulighet": delmal->.visningsnavn,
+                                  "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
+                                       "flettefelt": markDefs[].flettefeltReferanse 
+                                  }  
+                              }
+                  }
+                }
+            )
         }
   }[0]`;
 

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -14,6 +14,7 @@ export type Flettefelt = string[];
 export interface IAvansertDokumentVariabler {
   flettefelter: Flettefelter;
   delmaler: IDelmaler;
+  fritekstområder: IFritekstområder;
   valgfelter: IValgfelter;
   htmlfelter: IHtmlfelter;
 }
@@ -50,6 +51,15 @@ export interface IFritekstbrev {
 export interface IDelmaler {
   [delmalId: string]: IAvansertDokumentVariabler[];
 }
+
+export interface IFritekstområder {
+  [id: string]: FritekstAvsnitt[];
+}
+
+type FritekstAvsnitt = {
+  deloverskrift: string;
+  innhold: string;
+};
 
 export interface IHtmlfelter {
   [key: string]: string;


### PR DESCRIPTION
[Favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11847)

### Hvorfor er dette nødvendig?
Vi ønsker å kunne legge til fritekstområder i avansert dokument (våre brevmaler) fordi det gjør det mulig å bruke tabell i fritekstbrev <3

### Hva er gjort? 🔥
Henter fritekstområder fra sanity slik at de sendes med til ef-sak-frontend når brevmenyen skal bygges. 

Lagt til en serializer for fritekstområder som mapper innholdet inn i pdf på riktig sted. 

### Hører sammen med 🤝

- [PR i familie-sanity-brev](https://github.com/navikt/familie-sanity-brev/pull/372)
- [PR i familie-brev](https://github.com/navikt/familie-ef-sak-frontend/pull/2165)