### PR TITLE
Mer space mellom tekst og hilsen i manuelt brev

### DIFF
--- a/src/server/lagManueltBrevHtml.tsx
+++ b/src/server/lagManueltBrevHtml.tsx
@@ -30,6 +30,7 @@ export const lagManueltBrevHtml = (brevMedSignatur: IFritekstbrevMedSignatur) =>
           </p>
         ))}
         <div>
+          <br />
           <p style={{ float: 'left' }}>
             <div>Med vennlig hilsen </div>
             <div>{brevMedSignatur.enhet || 'NAV Arbeid og ytelser'}</div>


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12217

Før:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/937168/226965864-6517af91-1859-4867-af15-6f827b08f443.png">


Etter: 
<img width="476" alt="image" src="https://user-images.githubusercontent.com/937168/226965185-427a204e-5379-4440-b133-8d33f870de23.png">
