### PR TITLE
Lagt til CDN url for Sanity i preprod og prod

### DIFF
--- a/.build/nais-dev.yaml
+++ b/.build/nais-dev.yaml
@@ -45,6 +45,7 @@ spec:
         - application: familie-dokument
       external:
         - host: appres.nav.no
+        - host: xsrv1mh6.api.sanity.io
         - host: xsrv1mh6.apicdn.sanity.io
   env:
     - name: APP_VERSION

--- a/.build/nais-dev.yaml
+++ b/.build/nais-dev.yaml
@@ -45,7 +45,7 @@ spec:
         - application: familie-dokument
       external:
         - host: appres.nav.no
-        - host: xsrv1mh6.api.sanity.io
+        - host: xsrv1mh6.apicdn.sanity.io
   env:
     - name: APP_VERSION
       value: '{{version}}'

--- a/.build/nais-prod.yaml
+++ b/.build/nais-prod.yaml
@@ -46,6 +46,7 @@ spec:
       external:
         - host: appres.nav.no
         - host: xsrv1mh6.api.sanity.io
+        - host: xsrv1mh6.apicdn.sanity.io
   env:
     - name: APP_VERSION
       value: '{{version}}'


### PR DESCRIPTION
Fikk SSL feil i preprod ved kall mot Sanity. Ser ut til at vi bruker CDN versjon av SanityClient og derfor også må definere CDN url i `outbound.external`.