### PR TITLE
Legger til manglende aktiviteter for søkers og annen forelders aktivitet (EØS praksisendring)

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build and push Docker container
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build and push Docker container
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/src/baks/formateringsvalg.ts
+++ b/src/baks/formateringsvalg.ts
@@ -1,12 +1,6 @@
 import { Feil } from '../server/utils/Feil';
 import type { BegrunnelseMedData, IEØSBegrunnelsedata, IStandardbegrunnelsedata } from './typer';
-import {
-  AnnenForeldersAktivitet,
-  Begrunnelsetype,
-  SøkersAktivitet,
-  SøkersRettTilUtvidet,
-  ValgfeltMuligheter,
-} from './typer';
+import { Aktivitet, Begrunnelsetype, SøkersRettTilUtvidet, ValgfeltMuligheter } from './typer';
 
 export const hentForBarnFodtValg = (data: BegrunnelseMedData): ValgfeltMuligheter => {
   if (data.antallBarn === 0) {
@@ -117,8 +111,8 @@ export const hentDegDereEllerSegValg = (data: BegrunnelseMedData): ValgfeltMulig
   } else {
     if (data.antallBarn === 0) {
       throw new Feil(
-          `Må ha enten barn eller søker for å bruke ${valgfeltNavn} formulering for begrunnelse med apiNavn=${data.apiNavn}`,
-          400,
+        `Må ha enten barn eller søker for å bruke ${valgfeltNavn} formulering for begrunnelse med apiNavn=${data.apiNavn}`,
+        400,
       );
     } else {
       return ValgfeltMuligheter.KUN_BARN;
@@ -190,33 +184,41 @@ export const søkersAktivitetValg = (data: BegrunnelseMedData): ValgfeltMulighet
   }
 
   switch (data.sokersAktivitet) {
-    case SøkersAktivitet.ARBEIDER:
-    case SøkersAktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
+    case Aktivitet.ARBEIDER:
+    case Aktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
       return ValgfeltMuligheter.ARBEIDER;
-    case SøkersAktivitet.MOTTAR_UFØRETRYGD:
+    case Aktivitet.MOTTAR_UFØRETRYGD:
       return ValgfeltMuligheter.MOTTAR_UFØRETRYGD;
-    case SøkersAktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN:
+    case Aktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN:
       return ValgfeltMuligheter.FÅR_PENGER_SOM_ERSTATTER_LØNN;
-    case SøkersAktivitet.MOTTAR_PENSJON:
+    case Aktivitet.MOTTAR_PENSJON:
       return ValgfeltMuligheter.SØKER_MOTTAR_PENSJON;
-    case SøkersAktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
+    case Aktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
       return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
-    case SøkersAktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:
+    case Aktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:
       return ValgfeltMuligheter.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP;
-    case SøkersAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL:
+    case Aktivitet.ARBEIDER_PÅ_NORSK_SOKKEL:
       return ValgfeltMuligheter.ARBEIDER_PÅ_NORSK_SOKKEL;
-    case SøkersAktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP:
+    case Aktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP:
       return ValgfeltMuligheter.ARBEIDER_FOR_NORSK_FLYSELSKAP;
-    case SøkersAktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON:
+    case Aktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON:
       return ValgfeltMuligheter.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
-    case SøkersAktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+    case Aktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
       return ValgfeltMuligheter.MOTTAR_PENSJON_FRA_NORGE_UNDER_OPPHOLD_I_UTLANDET;
-    case SøkersAktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+    case Aktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
       return ValgfeltMuligheter.UTBETALING_FRA_NAV_I_UTLANDET;
-    case SøkersAktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+    case Aktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
       return ValgfeltMuligheter.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
-    case SøkersAktivitet.INAKTIV:
+    case Aktivitet.INAKTIV:
       return ValgfeltMuligheter.IKKE_I_ARBEIDSAKTIVITET;
+
+    // Ved selvstendig rett kan søker også ha følgende aktiviteter
+    case Aktivitet.I_ARBEID:
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_I_ARBEID;
+    case Aktivitet.FORSIKRET_I_BOSTEDSLAND:
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_FORSIKRET;
+    case Aktivitet.UTSENDT_ARBEIDSTAKER:
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER;
     default:
       throw new Feil(
         `Ingen valg for søkers aktivitet="${data.sokersAktivitet}" ved bruk av
@@ -233,19 +235,42 @@ export const annenForeldersAktivitetValg = (data: BegrunnelseMedData): ValgfeltM
     throw lagFeilStøttesKunForEØS(valgfeltNavn, data);
   }
   switch (data.annenForeldersAktivitet) {
-    case AnnenForeldersAktivitet.I_ARBEID:
+    case Aktivitet.I_ARBEID:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_I_ARBEID;
-    case AnnenForeldersAktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN:
+    case Aktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_UTBETALING;
-    case AnnenForeldersAktivitet.MOTTAR_PENSJON:
+    case Aktivitet.MOTTAR_PENSJON:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_PENSJON;
-    case AnnenForeldersAktivitet.FORSIKRET_I_BOSTEDSLAND:
+    case Aktivitet.FORSIKRET_I_BOSTEDSLAND:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_FORSIKRET;
-    case AnnenForeldersAktivitet.INAKTIV:
+    case Aktivitet.INAKTIV:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_INAKTIV;
-    case AnnenForeldersAktivitet.UTSENDT_ARBEIDSTAKER:
+    case Aktivitet.UTSENDT_ARBEIDSTAKER:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER;
-    case AnnenForeldersAktivitet.IKKE_AKTUELT:
+
+    // Ved selvstendig rett kan annen forelder ha følgende aktiviteter
+    case Aktivitet.ARBEIDER:
+    case Aktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
+      return ValgfeltMuligheter.ARBEIDER;
+    case Aktivitet.MOTTAR_UFØRETRYGD:
+      return ValgfeltMuligheter.MOTTAR_UFØRETRYGD;
+    case Aktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
+      return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
+    case Aktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:
+      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP;
+    case Aktivitet.ARBEIDER_PÅ_NORSK_SOKKEL:
+      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSK_SOKKEL;
+    case Aktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP:
+      return ValgfeltMuligheter.ARBEIDER_FOR_NORSK_FLYSELSKAP;
+    case Aktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON:
+      return ValgfeltMuligheter.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
+    case Aktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+      return ValgfeltMuligheter.MOTTAR_PENSJON_FRA_NORGE_UNDER_OPPHOLD_I_UTLANDET;
+    case Aktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+      return ValgfeltMuligheter.UTBETALING_FRA_NAV_I_UTLANDET;
+    case Aktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
+      return ValgfeltMuligheter.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
+    case Aktivitet.IKKE_AKTUELT:
     default:
       throw new Feil(
         `Ingen valg for annen forelders aktivitet="${data.annenForeldersAktivitet}" ved bruk av

--- a/src/baks/typer.ts
+++ b/src/baks/typer.ts
@@ -25,8 +25,8 @@ export interface IStandardbegrunnelsedata {
 
 export interface IEØSBegrunnelsedata {
   apiNavn: string;
-  sokersAktivitet: SøkersAktivitet;
-  annenForeldersAktivitet: AnnenForeldersAktivitet;
+  sokersAktivitet: Aktivitet;
+  annenForeldersAktivitet: Aktivitet;
   annenForeldersAktivitetsland?: string;
   sokersAktivitetsland?: string;
   barnetsBostedsland: string;
@@ -155,7 +155,7 @@ export enum Begrunnelsetype {
   FRITEKST = 'FRITEKST',
 }
 
-export enum SøkersAktivitet {
+export enum Aktivitet {
   ARBEIDER = 'ARBEIDER',
   SELVSTENDIG_NÆRINGSDRIVENDE = 'SELVSTENDIG_NÆRINGSDRIVENDE',
   MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN = 'MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN',
@@ -170,14 +170,8 @@ export enum SøkersAktivitet {
   MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
   MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
   INAKTIV = 'INAKTIV',
-}
-
-export enum AnnenForeldersAktivitet {
   I_ARBEID = 'I_ARBEID',
-  MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN = 'MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN',
   FORSIKRET_I_BOSTEDSLAND = 'FORSIKRET_I_BOSTEDSLAND',
-  MOTTAR_PENSJON = 'MOTTAR_PENSJON',
-  INAKTIV = 'INAKTIV',
   IKKE_AKTUELT = 'IKKE_AKTUELT',
   UTSENDT_ARBEIDSTAKER = 'UTSENDT_ARBEIDSTAKER',
 }


### PR DESCRIPTION
Favro: [NAV-15586](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15586)
Har slått sammen enumen for `SøkersAktivitet` og `AnnenForeldersAktivitet` til enumen `Aktivitet` da alle aktiviteter kan forekomme for både søker og annen forelder. Man har fortsatt mulighet til å justere valgfelt mulighetene unikt for annen forelder og søker. 