### PR TITLE
Lagt til egne valgfelt-muligheter for annen forelder og søker for aktiviteter de deler

### DIFF
--- a/src/baks/formateringsvalg.ts
+++ b/src/baks/formateringsvalg.ts
@@ -214,11 +214,11 @@ export const søkersAktivitetValg = (data: BegrunnelseMedData): ValgfeltMulighet
 
     // Ved selvstendig rett kan søker også ha følgende aktiviteter
     case Aktivitet.I_ARBEID:
-      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_I_ARBEID;
+      return ValgfeltMuligheter.I_ARBEID;
     case Aktivitet.FORSIKRET_I_BOSTEDSLAND:
-      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_FORSIKRET;
+      return ValgfeltMuligheter.FORSIKRET_I_BOSTEDSLAND;
     case Aktivitet.UTSENDT_ARBEIDSTAKER:
-      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER;
+      return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER;
     default:
       throw new Feil(
         `Ingen valg for søkers aktivitet="${data.sokersAktivitet}" ved bruk av
@@ -251,25 +251,25 @@ export const annenForeldersAktivitetValg = (data: BegrunnelseMedData): ValgfeltM
     // Ved selvstendig rett kan annen forelder ha følgende aktiviteter
     case Aktivitet.ARBEIDER:
     case Aktivitet.SELVSTENDIG_NÆRINGSDRIVENDE:
-      return ValgfeltMuligheter.ARBEIDER;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_ARBEIDER;
     case Aktivitet.MOTTAR_UFØRETRYGD:
-      return ValgfeltMuligheter.MOTTAR_UFØRETRYGD;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD;
     case Aktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE:
-      return ValgfeltMuligheter.UTSENDT_ARBEIDSTAKER_FRA_NORGE;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER_FRA_NORGE;
     case Aktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP:
-      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_ARBEIDER_PA_NORSKREGISTRERT_SKIP;
     case Aktivitet.ARBEIDER_PÅ_NORSK_SOKKEL:
-      return ValgfeltMuligheter.ARBEIDER_PÅ_NORSK_SOKKEL;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_ARBEIDER_PA_NORSK_SOKKEL;
     case Aktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP:
-      return ValgfeltMuligheter.ARBEIDER_FOR_NORSK_FLYSELSKAP;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_ARBEIDER_FOR_NORSK_FLYSELSKAP;
     case Aktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON:
-      return ValgfeltMuligheter.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON;
     case Aktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
-      return ValgfeltMuligheter.MOTTAR_PENSJON_FRA_NORGE_UNDER_OPPHOLD_I_UTLANDET;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
     case Aktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
-      return ValgfeltMuligheter.UTBETALING_FRA_NAV_I_UTLANDET;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
     case Aktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
-      return ValgfeltMuligheter.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
     case Aktivitet.IKKE_AKTUELT:
     default:
       throw new Feil(

--- a/src/baks/typer.ts
+++ b/src/baks/typer.ts
@@ -100,12 +100,26 @@ export enum ValgfeltMuligheter {
   MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'mottarUfoeretrygdFraNAVUnderOppholdIUtlandet',
   MOTTAR_PENSJON_FRA_NORGE_UNDER_OPPHOLD_I_UTLANDET = 'mottarPensjonFraNorgeUnderOppholdIUtlandet',
 
+  I_ARBEID = 'iArbeid',
+  FORSIKRET_I_BOSTEDSLAND = 'forsikretIBostedsland',
+  UTSENDT_ARBEIDSTAKER = 'utsendtArbeidstaker',
+
   EOS_ANNEN_FORELDER_I_ARBEID = 'eosAnnenForelderIArbeid',
   EOS_ANNEN_FORELDER_MOTTAR_UTBETALING = 'eosAnnenForelderMottarUtbetalingSomErstatterLonn',
   EOS_ANNEN_FORELDER_MOTTAR_PENSJON = 'eosAnnenForelderMottarPensjon',
   EOS_ANNEN_FORELDER_FORSIKRET = 'eosAnnenForelderForsikretIBostedsland',
   EOS_ANNEN_FORELDER_INAKTIV = 'eosAnnenForelderInaktiv',
   EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER = 'eosAnnenForelderUtsendtArbeidstaker',
+  EOS_ANNEN_FORELDER_ARBEIDER = 'eosAnnenForelderArbeider',
+  EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD = 'eosAnnenForelderMottarUfoeretrygd',
+  EOS_ANNEN_FORELDER_UTSENDT_ARBEIDSTAKER_FRA_NORGE = 'eosAnnenForelderUtsendtArbeidstakerFraNorge',
+  EOS_ANNEN_FORELDER_ARBEIDER_PA_NORSKREGISTRERT_SKIP = 'eosAnnenForelderArbeiderPaNorskregistrertSkip',
+  EOS_ANNEN_FORELDER_ARBEIDER_PA_NORSK_SOKKEL = 'eosAnnenForelderArbeiderPaNorskSokkel',
+  EOS_ANNEN_FORELDER_ARBEIDER_FOR_NORSK_FLYSELSKAP = 'eosAnnenForelderArbeiderForNorskFlyselskap',
+  EOS_ANNEN_FORELDER_ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON = 'eosAnnenForelderArbeiderVedUtenlandskUtenriksstasjon',
+  EOS_ANNEN_FORELDER_MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarPensjonFraNavUnderOppholdIUtlandet',
+  EOS_ANNEN_FORELDER_MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarUtbetalingFraNavUnderOppholdIUtlandet',
+  EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarUfoeretrygdFraNavUnderOppholdIUtlandet',
 }
 
 export interface SpanBlock {


### PR DESCRIPTION
Favro: [NAV-15586](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15586)

Trenger egne valgfelt-muligheter for annen forelder og søker for aktiviteter de deler, da de brukes på en annen måte i "Selvstendig rett"-begrunnelsene enn i øvrige begrunnelser.

Koden som overskrives er ikke tatt i bruk enda og er relatert til praksisendring EØS.

