### PR TITLE
Bruk distroless docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/baseimages/node-express:18
+FROM gcr.io/distroless/nodejs18-debian12:nonroot
 WORKDIR /var/server
 
 COPY dist ./dist
@@ -7,5 +7,7 @@ COPY package.json .
 
 EXPOSE 8001
 
-CMD ["yarn", "start"]
+ENV NODE_ENV=production
+
+CMD ["--es-module-specifier-resolution=node", "dist/src/server/index.js"]
 


### PR DESCRIPTION
I [navikt/baseimages](https://github.com/navikt/baseimages) står det
> NAIS baseimages are not actively maintained and should be considered deprecated.
Consider using official images or preferably distroless alternatives.

Endrer derfor dockerimage til distroless

Testet ok i [preprod](https://github.com/navikt/familie-brev/actions/runs/7845341122/job/21409540461)