### PR TITLE
`Dato: `-prefix for brevdato og oppdatert CSS for ikon og dato i `<Header />`

### DIFF
--- a/src/server/blankett/components/Header.tsx
+++ b/src/server/blankett/components/Header.tsx
@@ -14,9 +14,11 @@ function Header(props: HeaderProps) {
 
   return (
     <div className={'header'}>
-      <div className="ikon-og-dato">
-        {visLogo && <NavIkon />}
-        <p>{dato}</p>
+      <div className="ikon-og-dato-wrapper">
+        <div className="ikon-og-dato">
+          {visLogo && <NavIkon />}
+          <p>{dato}</p>
+        </div>
       </div>
       <div className={'tittel-og-personinfo'}>
         <h2 className="tittel">{tittel.toUpperCase()}</h2>

--- a/src/server/components/Brevhode.tsx
+++ b/src/server/components/Brevhode.tsx
@@ -13,9 +13,11 @@ export const Brevhode = (props: BrevhodeProps) => {
 
   return (
     <div className={'header'}>
-      <div className="ikon-og-dato">
-        <NavIkon />
-        <p>{brevOpprettetDato}</p>
+      <div className="ikon-og-dato-wrapper">
+        <div className="ikon-og-dato">
+          <NavIkon />
+          <p>{brevOpprettetDato}</p>
+        </div>
       </div>
       <div className={'tittel-og-personinfo'}>
         <h2 className="tittel">{tittel.toUpperCase()}</h2>

--- a/src/server/components/Header.tsx
+++ b/src/server/components/Header.tsx
@@ -39,11 +39,15 @@ function Header(props: HeaderProps) {
     validerFlettefelt(organisasjonsnummer, 'organisasjonsnummer', apiNavn, false);
   gjelder && validerFlettefelt(gjelder, 'gjelder', apiNavn, false);
 
+  const brevDato = () => {
+    return `Dato: ${datoPlaceholder || brevOpprettetDato[0]}`;
+  };
+
   return (
     <div className={'header'}>
       <div className="ikon-og-dato">
         {visLogo && <NavIkon />}
-        <p>{datoPlaceholder || brevOpprettetDato[0]}</p>
+        <p>{brevDato()}</p>
       </div>
       <div className={'tittel-og-personinfo'}>
         <h2 className="tittel">{tittel.toUpperCase()}</h2>

--- a/src/server/components/Header.tsx
+++ b/src/server/components/Header.tsx
@@ -45,9 +45,11 @@ function Header(props: HeaderProps) {
 
   return (
     <div className={'header'}>
-      <div className="ikon-og-dato">
-        {visLogo && <NavIkon />}
-        <p>{brevDato()}</p>
+      <div className="ikon-og-dato-wrapper">
+        <div className="ikon-og-dato">
+          {visLogo && <NavIkon />}
+          <p>{brevDato()}</p>
+        </div>
       </div>
       <div className={'tittel-og-personinfo'}>
         <h2 className="tittel">{tittel.toUpperCase()}</h2>

--- a/src/server/søknadgenerator.tsx
+++ b/src/server/søknadgenerator.tsx
@@ -59,9 +59,11 @@ export const genererSøknadHtml = (søknad: ISøknad) => {
       </head>
       <body className={'body'}>
         <div className={'header'}>
-          <div className="ikon-og-dato">
-            <NavIkon />
-            <p>{dagensDatoFormatert()}</p>
+          <div className="ikon-og-dato-wrapper">
+            <div className="ikon-og-dato">
+              <NavIkon />
+              <p>{dagensDatoFormatert()}</p>
+            </div>
           </div>
           <div className={'stonad-tittel'}>
             <h1>{søknad.label}</h1>

--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -9,11 +9,13 @@ export default `
 
   .ikon-og-dato {
     float: right;
+    text-align: center;
   }
 
   .nav-ikon {
     width: 100px;
     height: 65px;
+    display: inline-block;
   }
 
   .inline {

--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -8,20 +8,12 @@ export default `
   }
 
   .ikon-og-dato {
-    position: absolute;
-    right: 0px;
-    top: 0px;
-    margin:0;
-    padding:0;
+    float: right;
   }
 
   .nav-ikon {
     width: 100px;
     height: 65px;
-    position: relative;
-    right: 0px;
-    margin: 0;
-    padding: 0;
   }
 
   .inline {

--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -6,9 +6,13 @@ export default `
     margin: 0;
     box-sizing: border-box;
   }
+  
+  .ikon-og-dato-wrapper {
+    text-align: right;
+  }
 
   .ikon-og-dato {
-    float: right;
+    display: inline-block;
     text-align: center;
   }
 
@@ -27,7 +31,7 @@ export default `
   }
 
   .tittel-og-personinfo {
-    margin-top: 200px;
+    margin-top: 80px;
   }
   
   .lenke {


### PR DESCRIPTION
Favro: [NAV-19966](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-19966)

Brevdato ble lest opp til slutt på første side med skjermleser. Vi ønsker at den skal leses opp først. Den kommer først i HTML dokumentet, men etter konvertering til PDF blir den lest opp til slutt. Det er også ønsket at brevdato skal prefixes med `Dato: `. Dette påvirker også brevene til EF.

* Har skrevet om CSS'en til klassene `ikon-og-dato` og `nav-ikon` til å ikke lenger bruke `position: relative` og `position: absolute` og `top: 0`, `right: 0`, og nå blir dato lest opp først på siden. Testet at logo og brevdato fortsatt ser riktig ut. Se skjermbilder under.
* Lagt til `Dato: `-prefix

Til info så ville `float: right` gitt rett leserekkefølge, men det er egentlig bare flaks. Bruker man `float: right` ellers på innhold vil dette også leses for tidlig. Løsningen blir derfor litt "rar", men det funker.

Styling-endring vil påvirke alle brev for EF og BAKS. `Dato: `-prefix gjelder foreløpig kun brev som blir generert med `hentDokumentHtml` og `hentAvansertDokumentHtml`. 

Skjermbilder:
Før:
![image](https://github.com/navikt/familie-brev/assets/70642183/db582a6a-3ae9-4bb7-a6ef-f2c6a401639d)

Etter:
![image](https://github.com/navikt/familie-brev/assets/70642183/671650f2-8ea2-4ba9-bc46-4b8d061fdcf9)
