### PR TITLE
Ta med 'Siste periode med overgangsstønad' i blankett

### DIFF
--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import Vilkårsvurdering from './Vilkårsvurdering';
-import Medlemskapsgrunnlag from './Medlemskapsgrunnlag';
-import LovligOppholdGrunnlag from './LovligOppholdGrunnlag';
-import SivilstandGrunnlag from './Sivilstand';
-import SamlivGrunnlag from './Samliv';
-import MorEllerFarGrunnlag from './MorEllerFarGrunnlag';
-import AleneomsorgGrunnlag from './AleneomsorgGrunnlag';
-import NyttBarnSammePartner from './NyttBarnSammePartner';
-import SagtOppEllerRedusertGrunnlag from './SagtOppEllerRedusertGrunnlag';
 import { Vedtak } from './Vedtak';
-import AlderPåBarnGrunnlag from './AlderPåBarnGrunnlag';
-import { TidligereHistorikk } from './TidligereHistorikk';
-import type {
-  IDokumentData,
-  IVurdering,
-  IVilkårGrunnlag,
-} from '../../../typer/dokumentApiBlankett';
+import type { IDokumentData, IVurdering } from '../../../typer/dokumentApiBlankett';
 import {
   VilkårGruppe,
   Vilkår,
   EBehandlingÅrsak,
   vilkårTypeTilTekst,
 } from '../../../typer/dokumentApiBlankett';
+import { RegistergrunnlagForVilkår } from './RegistergrunnlagForVilkår';
 
 interface DokumentProps {
   dokumentData: IDokumentData;
@@ -70,7 +57,10 @@ function gjelderDetteVilkåret(vurdering: IVurdering, vilkårgruppe: string): bo
 
 const Dokument = (dokumentProps: DokumentProps) => {
   const dokumentData = dokumentProps.dokumentData;
+  const tidligereVedtaksperioder = dokumentData.behandling.tidligereVedtaksperioder;
+  const grunnlag = dokumentData.vilkår.grunnlag;
   const erManuellGOmregning = dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
+
   return (
     <div>
       {!erManuellGOmregning &&
@@ -78,25 +68,27 @@ const Dokument = (dokumentProps: DokumentProps) => {
           const vurderinger = dokumentData.vilkår.vurderinger.filter(vurdering =>
             gjelderDetteVilkåret(vurdering, vilkårgruppe),
           );
+
           if (vurderinger.length === 0) {
             return null;
           }
-          const grunnlag = dokumentData.vilkår.grunnlag;
+
           return vurderinger.map(vurdering => {
             return (
               <div key={vurdering.id} className={'blankett-page-break'}>
                 <h2>{vilkårTypeTilTekst[vurdering.vilkårType]}</h2>
-                {registergrunnlagForVilkår(grunnlag, vilkårgruppe, vurdering.barnId)}
-                {vurdering.vilkårType === Vilkår.TIDLIGERE_VEDTAKSPERIODER && (
-                  <TidligereHistorikk
-                    tidligereVedtaksperioder={dokumentData.behandling.tidligereVedtaksperioder}
-                  />
-                )}
+                <RegistergrunnlagForVilkår
+                  grunnlag={grunnlag}
+                  vilkårgruppe={vilkårgruppe}
+                  barnId={vurdering.barnId}
+                  tidligereVedtaksperioder={tidligereVedtaksperioder}
+                />
                 <Vilkårsvurdering vurdering={vurdering} />
               </div>
             );
           });
         })}
+
       <Vedtak
         stønadstype={dokumentData.behandling.stønadstype}
         vedtak={dokumentData.vedtak}
@@ -107,38 +99,5 @@ const Dokument = (dokumentProps: DokumentProps) => {
     </div>
   );
 };
-
-function registergrunnlagForVilkår(
-  grunnlag: IVilkårGrunnlag,
-  vilkårgruppe: string,
-  barnId?: string,
-) {
-  switch (vilkårgruppe) {
-    case VilkårGruppe.MEDLEMSKAP:
-      return <Medlemskapsgrunnlag medlemskap={grunnlag.medlemskap} />;
-    case VilkårGruppe.LOVLIG_OPPHOLD:
-      return <LovligOppholdGrunnlag medlemskap={grunnlag.medlemskap} />;
-    case VilkårGruppe.SIVILSTAND:
-      return <SivilstandGrunnlag sivilstand={grunnlag.sivilstand} />;
-    case VilkårGruppe.SAMLIV:
-      return <SamlivGrunnlag />;
-    case VilkårGruppe.MOR_ELLER_FAR:
-      return <MorEllerFarGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} />;
-    case VilkårGruppe.ALENEOMSORG:
-      return <AleneomsorgGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
-    case VilkårGruppe.ALDER_PÅ_BARN:
-      return <AlderPåBarnGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
-    case VilkårGruppe.NYTT_BARN_SAMME_PARTNER:
-      return <NyttBarnSammePartner barnMedSamvær={grunnlag.barnMedSamvær} />;
-    case VilkårGruppe.SAGT_OPP_ELLER_REDUSERT:
-      return (
-        <SagtOppEllerRedusertGrunnlag
-          harAvsluttetArbeidsforhold={grunnlag.harAvsluttetArbeidsforhold}
-        />
-      );
-    default:
-      return <div />;
-  }
-}
 
 export default Dokument;

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -60,6 +60,7 @@ const Dokument = (dokumentProps: DokumentProps) => {
   const tidligereVedtaksperioder = dokumentData.behandling.tidligereVedtaksperioder;
   const grunnlag = dokumentData.vilkår.grunnlag;
   const erManuellGOmregning = dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
+  const stønadstype = dokumentData.behandling.stønadstype;
 
   return (
     <div>
@@ -82,6 +83,7 @@ const Dokument = (dokumentProps: DokumentProps) => {
                   vilkårgruppe={vilkårgruppe}
                   barnId={vurdering.barnId}
                   tidligereVedtaksperioder={tidligereVedtaksperioder}
+                  stønadstype={stønadstype}
                 />
                 <Vilkårsvurdering vurdering={vurdering} />
               </div>

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -48,7 +48,7 @@ export const InntektGrunnlag: React.FC<{
                   {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
                 </td>
                 <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
-                {stønadstype !== StønadType.BARNETILSYN ? (
+                {stønadstype === StønadType.BARNETILSYN ? (
                   <>
                     <td>{periode.inntekt ?? 0}</td>
                     {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { formaterIsoDato } from '../../utils/util';
 import type {
   ITidligereVedtaksperioder,
-  IGrunnlagsdataPeriodeHistorikkOvergangsstønad,
+  IGrunnlagsdataSistePeriodeOvergangsstønad,
 } from '../../../typer/dokumentApiBlankett';
 import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
 
@@ -10,7 +10,7 @@ export const InntektGrunnlag: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
   const sistePeriodeMedOvergangsstønad =
-    tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad?.[0];
+    tidligereVedtaksperioder?.sak?.sistePeriodeMedOvergangsstønad;
 
   if (!sistePeriodeMedOvergangsstønad) {
     return null;
@@ -35,7 +35,7 @@ export const InntektGrunnlag: React.FC<{
         </thead>
         <tbody>
           {[sistePeriodeMedOvergangsstønad].map(
-            (periode: IGrunnlagsdataPeriodeHistorikkOvergangsstønad, index) => (
+            (periode: IGrunnlagsdataSistePeriodeOvergangsstønad, index) => (
               <tr key={index}>
                 <td>
                   {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -30,7 +30,7 @@ export const InntektGrunnlag: React.FC<{
           <tr>
             <th>Periode</th>
             <th>Type</th>
-            {stønadstype !== StønadType.BARNETILSYN ? (
+            {stønadstype === StønadType.BARNETILSYN ? (
               <>
                 <th>Inntekt</th>
                 {skalViseSamordning && <th>Samordning</th>}

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -3,12 +3,15 @@ import { formaterIsoDato } from '../../utils/util';
 import type {
   ITidligereVedtaksperioder,
   IGrunnlagsdataSistePeriodeOvergangsstønad,
+  EStønadType,
 } from '../../../typer/dokumentApiBlankett';
 import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+import { EStønadType as StønadType } from '../../../typer/dokumentApiBlankett';
 
 export const InntektGrunnlag: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
-}> = ({ tidligereVedtaksperioder }) => {
+  stønadstype: EStønadType;
+}> = ({ tidligereVedtaksperioder, stønadstype }) => {
   const sistePeriodeMedOvergangsstønad =
     tidligereVedtaksperioder?.sak?.sistePeriodeMedOvergangsstønad;
 
@@ -27,8 +30,14 @@ export const InntektGrunnlag: React.FC<{
           <tr>
             <th>Periode</th>
             <th>Type</th>
-            <th>Inntekt</th>
-            {skalViseSamordning && <th>Samordning</th>}
+            {stønadstype !== StønadType.BARNETILSYN ? (
+              <>
+                <th>Inntekt</th>
+                {skalViseSamordning && <th>Samordning</th>}
+              </>
+            ) : (
+              <th>Aktivitet</th>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -39,8 +48,14 @@ export const InntektGrunnlag: React.FC<{
                   {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
                 </td>
                 <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
-                <td>{periode.inntekt ?? 0}</td>
-                {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}
+                {stønadstype !== StønadType.BARNETILSYN ? (
+                  <>
+                    <td>{periode.inntekt ?? 0}</td>
+                    {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}
+                  </>
+                ) : (
+                  <td>{periode.aktivitet}</td>
+                )}
               </tr>
             ),
           )}

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -16,9 +16,7 @@ export const InntektGrunnlag: React.FC<{
     return null;
   }
 
-  const skalViseSamordning =
-    sistePeriodeMedOvergangsstønad.samordningsfradrag &&
-    sistePeriodeMedOvergangsstønad.samordningsfradrag > 0;
+  const skalViseSamordning = sistePeriodeMedOvergangsstønad.samordningsfradrag > 0;
 
   return (
     <>

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -5,7 +5,7 @@ import type {
   IGrunnlagsdataSistePeriodeOvergangsstønad,
   EStønadType,
 } from '../../../typer/dokumentApiBlankett';
-import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+import { aktivitetsTypeTilTekst, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
 import { EStønadType as StønadType } from '../../../typer/dokumentApiBlankett';
 
 export const InntektGrunnlag: React.FC<{
@@ -54,7 +54,7 @@ export const InntektGrunnlag: React.FC<{
                     {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}
                   </>
                 ) : (
-                  <td>{periode.aktivitet ?? ''}</td>
+                  <td>{periode.aktivitet ? aktivitetsTypeTilTekst[periode.aktivitet] : ''}</td>
                 )}
               </tr>
             ),

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -54,7 +54,7 @@ export const InntektGrunnlag: React.FC<{
                     {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}
                   </>
                 ) : (
-                  <td>{periode.aktivitet}</td>
+                  <td>{periode.aktivitet ?? ''}</td>
                 )}
               </tr>
             ),

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -4,15 +4,15 @@ import type {
   ITidligereVedtaksperioder,
   IGrunnlagsdataPeriodeHistorikkOvergangsstønad,
 } from '../../../typer/dokumentApiBlankett';
-import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+import { aktivitetsTypeTilTekst, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
 
 export const InntektGrunnlag: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
-  if (
-    !tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad ||
-    tidligereVedtaksperioder.sak.periodeHistorikkOvergangsstønad.length === 0
-  ) {
+  const sistePeriodeMedOvergangsstønad =
+    tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad?.[0];
+
+  if (!sistePeriodeMedOvergangsstønad) {
     return null;
   }
 
@@ -30,15 +30,15 @@ export const InntektGrunnlag: React.FC<{
           </tr>
         </thead>
         <tbody>
-          {tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad.map(
+          {[sistePeriodeMedOvergangsstønad].map(
             (periode: IGrunnlagsdataPeriodeHistorikkOvergangsstønad, index) => (
               <tr key={index}>
                 <td>
                   {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
                 </td>
                 <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
-                <td>{periode.aktivitet}</td>
-                <td>{periode.inntekt}</td>
+                <td>{periode.aktivitet ? aktivitetsTypeTilTekst[periode.aktivitet] : ''}</td>
+                <td>{periode.inntekt ?? 0}</td>
               </tr>
             ),
           )}

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { formaterIsoDato } from '../../utils/util';
+import type {
+  ITidligereVedtaksperioder,
+  IGrunnlagsdataPeriodeHistorikkOvergangsstønad,
+} from '../../../typer/dokumentApiBlankett';
+import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+
+export const InntektGrunnlag: React.FC<{
+  tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
+}> = ({ tidligereVedtaksperioder }) => {
+  if (
+    !tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad ||
+    tidligereVedtaksperioder.sak.periodeHistorikkOvergangsstønad.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <h3>Registerdata</h3>
+      <p>Siste periode med overgangsstønad</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Periode</th>
+            <th>Type</th>
+            <th>Aktivitet</th>
+            <th>Inntekt</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad.map(
+            (periode: IGrunnlagsdataPeriodeHistorikkOvergangsstønad, index) => (
+              <tr key={index}>
+                <td>
+                  {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
+                </td>
+                <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
+                <td>{periode.aktivitet}</td>
+                <td>{periode.inntekt}</td>
+              </tr>
+            ),
+          )}
+        </tbody>
+      </table>
+    </>
+  );
+};

--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -4,7 +4,7 @@ import type {
   ITidligereVedtaksperioder,
   IGrunnlagsdataPeriodeHistorikkOvergangsstønad,
 } from '../../../typer/dokumentApiBlankett';
-import { aktivitetsTypeTilTekst, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+import { periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
 
 export const InntektGrunnlag: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
@@ -16,6 +16,10 @@ export const InntektGrunnlag: React.FC<{
     return null;
   }
 
+  const skalViseSamordning =
+    sistePeriodeMedOvergangsstønad.samordningsfradrag &&
+    sistePeriodeMedOvergangsstønad.samordningsfradrag > 0;
+
   return (
     <>
       <h3>Registerdata</h3>
@@ -25,8 +29,8 @@ export const InntektGrunnlag: React.FC<{
           <tr>
             <th>Periode</th>
             <th>Type</th>
-            <th>Aktivitet</th>
             <th>Inntekt</th>
+            {skalViseSamordning && <th>Samordning</th>}
           </tr>
         </thead>
         <tbody>
@@ -37,8 +41,8 @@ export const InntektGrunnlag: React.FC<{
                   {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
                 </td>
                 <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
-                <td>{periode.aktivitet ? aktivitetsTypeTilTekst[periode.aktivitet] : ''}</td>
                 <td>{periode.inntekt ?? 0}</td>
+                {skalViseSamordning && <td>{periode.samordningsfradrag}</td>}
               </tr>
             ),
           )}

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Medlemskapsgrunnlag from './Medlemskapsgrunnlag';
+import LovligOppholdGrunnlag from './LovligOppholdGrunnlag';
+import SivilstandGrunnlag from './Sivilstand';
+import SamlivGrunnlag from './Samliv';
+import MorEllerFarGrunnlag from './MorEllerFarGrunnlag';
+import AleneomsorgGrunnlag from './AleneomsorgGrunnlag';
+import NyttBarnSammePartner from './NyttBarnSammePartner';
+import SagtOppEllerRedusertGrunnlag from './SagtOppEllerRedusertGrunnlag';
+import AlderPåBarnGrunnlag from './AlderPåBarnGrunnlag';
+import { TidligereHistorikk } from './TidligereHistorikk';
+import type {
+  IVilkårGrunnlag,
+  ITidligereVedtaksperioder,
+} from '../../../typer/dokumentApiBlankett';
+import { VilkårGruppe, Vilkår } from '../../../typer/dokumentApiBlankett';
+import { InntektGrunnlag } from './InntektGrunnlag';
+
+export interface RegistergrunnlagForVilkårProps {
+  grunnlag: IVilkårGrunnlag;
+  vilkårgruppe: string;
+  barnId?: string;
+  tidligereVedtaksperioder?: ITidligereVedtaksperioder;
+}
+
+export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProps> = ({
+  grunnlag,
+  vilkårgruppe,
+  barnId,
+  tidligereVedtaksperioder,
+}) => {
+  switch (vilkårgruppe) {
+    case VilkårGruppe.MEDLEMSKAP:
+      return <Medlemskapsgrunnlag medlemskap={grunnlag.medlemskap} />;
+    case VilkårGruppe.LOVLIG_OPPHOLD:
+      return <LovligOppholdGrunnlag medlemskap={grunnlag.medlemskap} />;
+    case VilkårGruppe.SIVILSTAND:
+      return <SivilstandGrunnlag sivilstand={grunnlag.sivilstand} />;
+    case VilkårGruppe.SAMLIV:
+      return <SamlivGrunnlag />;
+    case VilkårGruppe.MOR_ELLER_FAR:
+      return <MorEllerFarGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} />;
+    case VilkårGruppe.ALENEOMSORG:
+      return <AleneomsorgGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
+    case VilkårGruppe.ALDER_PÅ_BARN:
+      return <AlderPåBarnGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
+    case VilkårGruppe.NYTT_BARN_SAMME_PARTNER:
+      return <NyttBarnSammePartner barnMedSamvær={grunnlag.barnMedSamvær} />;
+    case Vilkår.TIDLIGERE_VEDTAKSPERIODER:
+      return <TidligereHistorikk tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+    case Vilkår.INNTEKT:
+      return <InntektGrunnlag tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+    case VilkårGruppe.SAGT_OPP_ELLER_REDUSERT:
+      return (
+        <SagtOppEllerRedusertGrunnlag
+          harAvsluttetArbeidsforhold={grunnlag.harAvsluttetArbeidsforhold}
+        />
+      );
+    default:
+      return <div />;
+  }
+};

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -54,7 +54,12 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
       return <TidligereHistorikk tidligereVedtaksperioder={tidligereVedtaksperioder} />;
     case Vilkår.INNTEKT:
       if (stønadstype !== StønadType.OVERGANGSSTØNAD) {
-        return <InntektGrunnlag tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+        return (
+          <InntektGrunnlag
+            tidligereVedtaksperioder={tidligereVedtaksperioder}
+            stønadstype={stønadstype}
+          />
+        );
       }
       break;
     case VilkårGruppe.SAGT_OPP_ELLER_REDUSERT:

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -53,6 +53,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
     case Vilkår.TIDLIGERE_VEDTAKSPERIODER:
       return <TidligereHistorikk tidligereVedtaksperioder={tidligereVedtaksperioder} />;
     case Vilkår.INNTEKT:
+    case VilkårGruppe.RETT_TIL_OVERGANGSSTØNAD:
       if (stønadstype !== StønadType.OVERGANGSSTØNAD) {
         return (
           <InntektGrunnlag

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -12,7 +12,9 @@ import { TidligereHistorikk } from './TidligereHistorikk';
 import type {
   IVilkårGrunnlag,
   ITidligereVedtaksperioder,
+  EStønadType,
 } from '../../../typer/dokumentApiBlankett';
+import { EStønadType as StønadType } from '../../../typer/dokumentApiBlankett';
 import { VilkårGruppe, Vilkår } from '../../../typer/dokumentApiBlankett';
 import { InntektGrunnlag } from './InntektGrunnlag';
 
@@ -21,6 +23,7 @@ export interface RegistergrunnlagForVilkårProps {
   vilkårgruppe: string;
   barnId?: string;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
+  stønadstype: EStønadType;
 }
 
 export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProps> = ({
@@ -28,6 +31,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
   vilkårgruppe,
   barnId,
   tidligereVedtaksperioder,
+  stønadstype,
 }) => {
   switch (vilkårgruppe) {
     case VilkårGruppe.MEDLEMSKAP:
@@ -49,7 +53,10 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
     case Vilkår.TIDLIGERE_VEDTAKSPERIODER:
       return <TidligereHistorikk tidligereVedtaksperioder={tidligereVedtaksperioder} />;
     case Vilkår.INNTEKT:
-      return <InntektGrunnlag tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+      if (stønadstype !== StønadType.OVERGANGSSTØNAD) {
+        return <InntektGrunnlag tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+      }
+      break;
     case VilkårGruppe.SAGT_OPP_ELLER_REDUSERT:
       return (
         <SagtOppEllerRedusertGrunnlag

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -35,7 +35,7 @@ export interface IGrunnlagsdataPeriodeHistorikkOvergangsstønad {
   antallMåneder: number;
   antallMånederUtenBeløp: number;
   inntekt?: number;
-  aktivitet?: EAktivitet;
+  samordningsfradrag?: number;
 }
 
 export enum OverlappMedOvergangsstønad {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -26,6 +26,7 @@ interface ITidligereInnvilgetVedtak {
   harTidligereSkolepenger: boolean;
   periodeHistorikkOvergangsstønad?: IGrunnlagsdataPeriodeHistorikkOvergangsstønad[];
   periodeHistorikkBarnetilsyn?: IGrunnlagsdataPeriodeHistorikkBarnetilsyn[];
+  sistePeriodeMedOvergangsstønad: IGrunnlagsdataSistePeriodeOvergangsstønad;
 }
 
 export interface IGrunnlagsdataPeriodeHistorikkOvergangsstønad {
@@ -34,8 +35,14 @@ export interface IGrunnlagsdataPeriodeHistorikkOvergangsstønad {
   tom: string;
   antallMåneder: number;
   antallMånederUtenBeløp: number;
-  inntekt?: number;
-  samordningsfradrag?: number;
+}
+
+export interface IGrunnlagsdataSistePeriodeOvergangsstønad {
+  fom: string;
+  tom: string;
+  vedtaksperiodeType: EPeriodetype;
+  inntekt: number;
+  samordningsfradrag: number;
 }
 
 export enum OverlappMedOvergangsstønad {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -41,7 +41,7 @@ export interface IGrunnlagsdataSistePeriodeOvergangsstønad {
   fom: string;
   tom: string;
   vedtaksperiodeType: EPeriodetype;
-  aktivitet: EAktivitet;
+  aktivitet?: EAktivitet;
   inntekt: number;
   samordningsfradrag: number;
 }

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -34,6 +34,8 @@ export interface IGrunnlagsdataPeriodeHistorikkOvergangsstønad {
   tom: string;
   antallMåneder: number;
   antallMånederUtenBeløp: number;
+  inntekt?: number;
+  aktivitet?: EAktivitet;
 }
 
 export enum OverlappMedOvergangsstønad {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -240,6 +240,15 @@ export enum EAktivitet {
   FORSØRGER_MANGLER_TILSYNSORDNING = 'FORSØRGER_MANGLER_TILSYNSORDNING',
   FORSØRGER_ER_SYK = 'FORSØRGER_ER_SYK',
   BARNET_ER_SYKT = 'BARNET_ER_SYKT',
+  UTVIDELSE_FORSØRGER_I_UTDANNING = 'UTVIDELSE_FORSØRGER_I_UTDANNING',
+  UTVIDELSE_BARNET_SÆRLIG_TILSYNSKREVENDE = 'UTVIDELSE_BARNET_SÆRLIG_TILSYNSKREVENDE',
+  FORLENGELSE_MIDLERTIDIG_SYKDOM = 'FORLENGELSE_MIDLERTIDIG_SYKDOM',
+  FORLENGELSE_STØNAD_PÅVENTE_ARBEID = 'FORLENGELSE_STØNAD_PÅVENTE_ARBEID',
+  FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER = 'FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER',
+  FORLENGELSE_STØNAD_PÅVENTE_OPPSTART_KVALIFISERINGSPROGRAM = 'FORLENGELSE_STØNAD_PÅVENTE_OPPSTART_KVALIFISERINGSPROGRAM',
+  FORLENGELSE_STØNAD_PÅVENTE_TILSYNSORDNING = 'FORLENGELSE_STØNAD_PÅVENTE_TILSYNSORDNING',
+  FORLENGELSE_STØNAD_PÅVENTE_UTDANNING = 'FORLENGELSE_STØNAD_PÅVENTE_UTDANNING',
+  FORLENGELSE_STØNAD_UT_SKOLEÅRET = 'FORLENGELSE_STØNAD_UT_SKOLEÅRET',
 }
 
 export const aktivitetsTypeTilTekst: Record<EAktivitet, string> = {
@@ -253,6 +262,19 @@ export const aktivitetsTypeTilTekst: Record<EAktivitet, string> = {
   FORSØRGER_MANGLER_TILSYNSORDNING: 'Forsørger mangler tilsynsordning (§15-6 femte ledd)',
   FORSØRGER_ER_SYK: 'Forsørger er syk (§15-6 femte ledd)',
   BARNET_ER_SYKT: 'Barnet er sykt (§15-6 femte ledd)',
+  UTVIDELSE_BARNET_SÆRLIG_TILSYNSKREVENDE: 'Barnet er særlig tilsynskrevende (§15-8 tredje ledd)',
+  UTVIDELSE_FORSØRGER_I_UTDANNING: 'Forsørgeren er i utdanning (§15-8 andre ledd)',
+  FORLENGELSE_MIDLERTIDIG_SYKDOM:
+    'Forsørger eller barnet har en midlertidig sykdom (§15-8 fjerde ledd)',
+  FORLENGELSE_STØNAD_UT_SKOLEÅRET: 'Stønad ut skoleåret (§15-8 andre ledd)',
+  FORLENGELSE_STØNAD_PÅVENTE_ARBEID: 'Stønad i påvente av arbeid (§15-8 femte ledd)',
+  FORLENGELSE_STØNAD_PÅVENTE_UTDANNING: 'Stønad i påvente av utdanning (§15-8 femte ledd)',
+  FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER:
+    'Stønad i påvente av arbeid - reell arbeidssøker (§15-8 femte ledd)',
+  FORLENGELSE_STØNAD_PÅVENTE_OPPSTART_KVALIFISERINGSPROGRAM:
+    'Stønad i påvente av oppstart kvalifiseringsprogram',
+  FORLENGELSE_STØNAD_PÅVENTE_TILSYNSORDNING:
+    'Stønad i påvente av tilsynsordning (§15-8 femte ledd)',
 };
 
 export interface IPersonopplysninger {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -41,6 +41,7 @@ export interface IGrunnlagsdataSistePeriodeOvergangsstønad {
   fom: string;
   tom: string;
   vedtaksperiodeType: EPeriodetype;
+  aktivitet: EAktivitet;
   inntekt: number;
   samordningsfradrag: number;
 }


### PR DESCRIPTION
- Refaktorert kode i Dokument - funksjonen registergrunnlagForVilkår er tatt ut i egen fil og laget det som en komponent for å gjøre det mer lesbart. Lagt til nye komponenter/caser. 
- Laget komponenten InntektGrunnlag som viser det samme som blir vist i EF-sak under BT 'Siste periode med overgangsstønad'.


Bildet viser blanketten: 
![image](https://github.com/navikt/familie-brev/assets/141132903/a3a62cd4-c7e5-46d5-bdb9-0c27a5451dce)

Bildet viser det som Inntekt under aktivitet i OS:
![image](https://github.com/navikt/familie-brev/assets/141132903/ed380900-ff8f-41bd-879b-c441de4a3430)
