### PR TITLE
Sammensatt kontrollsak: SammensattKontrollsakSerializer for rendring av fritekst i sammensatte kontrollsaker

### DIFF
--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { IDokumentData, IDokumentDataMedPeriode } from '../../typer/dokumentApiBrev';
+import type { IDokumentData } from '../../typer/dokumentApiBrev';
 import { hentDokumentQuery } from '../sanity/Queries';
 import type { Datasett } from '../sanity/sanityClient';
 import { client } from '../sanity/sanityClient';
@@ -14,6 +14,7 @@ import { Feil } from '../utils/Feil';
 import LenkeSerializer from './serializers/LenkeSerializer';
 
 import { PortableText } from '@portabletext/react';
+import SammensattKontrollsakSerializer from './serializers/SammensattKontrollsakSerializer';
 
 interface DokumentProps {
   dokumentApiNavn: string;
@@ -67,10 +68,14 @@ const Dokument = (dokumentProps: DokumentProps) => {
               flettefelter: dokumentData?.flettefelter,
               dokumentApiNavn,
             }),
+          sammensattKontrollsakFritekst: (_: any) =>
+            SammensattKontrollsakSerializer({
+              dokumentData: dokumentData,
+            }),
           perioder: (props: any) =>
             PeriodeSerializer({
               sanityProps: props,
-              perioder: (dokumentData as IDokumentDataMedPeriode)?.perioder,
+              dokumentData: dokumentData,
               maalform,
               datasett,
               forelderApiNavn: dokumentApiNavn,

--- a/src/server/components/serializers/PeriodeSerializer.tsx
+++ b/src/server/components/serializers/PeriodeSerializer.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import type { Flettefelt, Flettefelter } from '../../../typer/dokumentApiBrev';
+import type {
+  Flettefelt,
+  Flettefelter,
+  IDokumentData,
+  IDokumentDataMedPeriode,
+} from '../../../typer/dokumentApiBrev';
 import FlettefeltSerializer from './FlettefeltSerializer';
 import BlockSerializer from './BlockSerializer';
 import type { Maalform } from '../../../typer/sanitygrensesnitt';
@@ -24,14 +29,26 @@ import { PortableText } from '@portabletext/react';
 
 interface IPeriodeProps {
   sanityProps: any;
-  perioder: IPeriodedata[];
+  dokumentData: IDokumentData | undefined;
   maalform: Maalform;
   datasett: Datasett;
   forelderApiNavn: string;
 }
 
 const PeriodeSerializer = (props: IPeriodeProps) => {
-  const { perioder, maalform, datasett, forelderApiNavn } = props;
+  const { dokumentData, maalform, datasett, forelderApiNavn } = props;
+
+  const erIDokumentDataMedPeriode = (
+    dokumentData: IDokumentData | IDokumentDataMedPeriode | undefined,
+  ): dokumentData is IDokumentDataMedPeriode => {
+    return (dokumentData as IDokumentDataMedPeriode)?.perioder !== undefined;
+  };
+
+  if (!erIDokumentDataMedPeriode(dokumentData)) {
+    return null;
+  }
+
+  const perioder = dokumentData.perioder;
 
   validerPeriode(forelderApiNavn, perioder);
 

--- a/src/server/components/serializers/SammensattKontrollsakSerializer.tsx
+++ b/src/server/components/serializers/SammensattKontrollsakSerializer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import type {
+  IDokumentData,
+  IDokumentDataSammensattKontrollsak,
+} from '../../../typer/dokumentApiBrev';
+
+interface Props {
+  dokumentData: IDokumentData | undefined;
+}
+
+const StyledParagraph = styled.p`
+  white-space: pre-wrap;
+`;
+const SammensattKontrollsakSerializer: React.FC<Props> = ({ dokumentData }) => {
+  const erIDokumentDataSammensattKontrollsak = (
+    dokumentData: IDokumentData | IDokumentDataSammensattKontrollsak | undefined,
+  ): dokumentData is IDokumentDataSammensattKontrollsak => {
+    return (
+      (dokumentData as IDokumentDataSammensattKontrollsak)?.sammensattKontrollsakFritekst !==
+      undefined
+    );
+  };
+
+  if (!erIDokumentDataSammensattKontrollsak(dokumentData)) {
+    return null;
+  }
+
+  const fritekst = dokumentData.sammensattKontrollsakFritekst;
+
+  const fritekstAvsnitt = fritekst.split('\n\n');
+
+  return fritekstAvsnitt.map((avsnitt, index) => (
+    <StyledParagraph key={index}>{avsnitt}</StyledParagraph>
+  ));
+};
+
+export default SammensattKontrollsakSerializer;

--- a/src/typer/dokumentApiBrev.ts
+++ b/src/typer/dokumentApiBrev.ts
@@ -85,6 +85,10 @@ export interface IDokumentDataMedPeriode extends IDokumentData {
   perioder: Flettefelter[];
 }
 
+export interface IDokumentDataSammensattKontrollsak extends IDokumentData {
+  sammensattKontrollsakFritekst: string;
+}
+
 export interface ISøknad {
   label: string;
   verdiliste: IVerdiliste[];


### PR DESCRIPTION
* Lagt til `SammensattKontrollsakSerializer` og tatt den i bruk i `Dokument`. Dersom `dokumentData` som sendes fra backend inneholder feltet `sammensattKontrollsakFritekst` rendrer vi friteksten.
* Justert `PeriodeSerializer` til å sjekke hvorvidt `dokumentData` inneholder feltet `perioder`. Dersom feltet ikke finnes rendres ingenting.

Bruker altså samme fremgangsmåte i `SammensattKontrollsakSerializer` og `PeriodeSerializer` for å bestemme om vi skal rendre noe eller ikke.

Har en avhengighet til PR i `familie-sanity-brev`: https://github.com/navikt/familie-sanity-brev/pull/609