### PR TITLE
Adressevisning hvis ikke samme adresse

### DIFF
--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -45,7 +45,13 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
     case VilkårGruppe.MOR_ELLER_FAR:
       return <MorEllerFarGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} />;
     case VilkårGruppe.ALENEOMSORG:
-      return <AleneomsorgGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
+      return (
+        <AleneomsorgGrunnlag
+          barnMedSamvær={grunnlag.barnMedSamvær}
+          barnId={barnId}
+          personalia={grunnlag.personalia}
+        />
+      );
     case VilkårGruppe.ALDER_PÅ_BARN:
       return <AlderPåBarnGrunnlag barnMedSamvær={grunnlag.barnMedSamvær} barnId={barnId} />;
     case VilkårGruppe.NYTT_BARN_SAMME_PARTNER:

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -296,12 +296,41 @@ export interface IVilkår {
 }
 
 export interface IVilkårGrunnlag {
+  personalia: IPersonalia;
   medlemskap: IMedlemskap;
   sivilstand: ISivilstandVilkår;
-  //bosituasjon: IBosituasjon;
   sivilstandsplaner: ISivilstandsplaner;
   barnMedSamvær: IBarnMedSamvær[];
   harAvsluttetArbeidsforhold: boolean;
+}
+
+export interface IPersonalia {
+  personIdent: string;
+  navn: INavn;
+  bostedsadresse?: IAdresse;
+}
+
+export interface INavn {
+  fornavn: string;
+  mellomnavn: string;
+  etternavn: string;
+  visningsnavn: string;
+}
+
+export interface IAdresse {
+  visningsadresse?: string;
+  type: AdresseType;
+  gyldigFraOgMed?: string;
+  gyldigTilOgMed?: string;
+  angittFlyttedato?: string;
+  erGjeldende: boolean;
+}
+
+export enum AdresseType {
+  BOSTEDADRESSE = 'BOSTEDADRESSE',
+  KONTAKTADRESSE = 'KONTAKTADRESSE',
+  KONTAKTADRESSE_UTLAND = 'KONTAKTADRESSE_UTLAND',
+  OPPHOLDSADRESSE = 'OPPHOLDSADRESSE',
 }
 
 export interface ISivilstandVilkår {
@@ -325,6 +354,8 @@ export interface IBarnMedSamværRegistergrunnlag {
   fødselsnummer?: string;
   harSammeAdresse?: boolean;
   forelder?: IAnnenForelder;
+  harDeltBostedVedGrunnlagsdataopprettelse: boolean;
+  adresse?: string;
 }
 
 export interface IBarnMedSamværSøknadsgrunnlag {


### PR DESCRIPTION
Ønsker å vise tabell med søker og gjeldene barn sin adresse hvis de ikke bor på samme adresse. Dette er fordi vi viser dette i ef-sak.

Bildet viser hvordan det ser ut i ef-sak. Det ene barnet har samme adresse, mens det andre ikke har det.
![image](https://github.com/navikt/familie-brev/assets/141132903/8e327d59-c478-46d8-955c-83dca5ca9810)

Blankett barnet som ikke er registrert på samme adresse:
![image](https://github.com/navikt/familie-brev/assets/141132903/cdd5a94a-fab1-49bb-9944-1062e6f5c656)

Registrert på samme adresse:
![image](https://github.com/navikt/familie-brev/assets/141132903/c071a33e-89e9-498a-9bc4-e8cacf37d47b)
