### PR TITLE
Nyere versjon av endepunkt + nyere versjon sanity api

### DIFF
--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -58,7 +58,7 @@ export const hentAvansertDokumentFelter_V20220307 = async (
                           ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ] {
                               "flettefelt": markDefs[].flettefeltReferanse
                           },
-                  "delmalValgfelt":  ^.${maalform}[defined(valgReferanse)].valgReferanse ->{
+                  "delmalValgfelt":  ${maalform}[defined(valgReferanse)].valgReferanse ->{
                           "valgfeltVisningsnavn":visningsnavn,
                           "valgFeltApiNavn": apiNavn,
                           "valgfeltBeskrivelse": beskrivelse,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -1,6 +1,5 @@
 import type { Maalform } from '../typer/sanitygrensesnitt';
-import { clientV2, Datasett } from './sanity/sanityClient';
-import { client } from './sanity/sanityClient';
+import { client, clientV2, Datasett } from './sanity/sanityClient';
 import { Feil } from './utils/Feil';
 
 export const hentFlettefelter = async (

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -25,7 +25,6 @@ export const hentAvansertDokumentFelter_V20220307 = async (
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "malNavn": apiNavn,
         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
-            "id": _id,
             "delmalApiNavn": apiNavn,
             "delmalNavn": visningsnavn,
             gruppeVisningsnavn,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -1,5 +1,5 @@
 import type { Maalform } from '../typer/sanitygrensesnitt';
-import type { Datasett } from './sanity/sanityClient';
+import { clientV2, Datasett } from './sanity/sanityClient';
 import { client } from './sanity/sanityClient';
 import { Feil } from './utils/Feil';
 
@@ -11,6 +11,73 @@ export const hentFlettefelter = async (
      "flettefeltReferanse" :  *[ _type=='flettefelt' ]
     }[0]`;
   return client(datasett)
+    .fetch(query)
+    .catch(error => {
+      throw new Feil(error.message, error.statusCode);
+    });
+};
+
+export const hentAvansertDokumentFelter_V20220307 = async (
+  datasett: Datasett,
+  maalform: Maalform,
+  avansertDokumentNavn: string,
+): Promise<string> => {
+  const query = `*[apiNavn == "${avansertDokumentNavn}"]{
+        "malNavn": apiNavn,
+        "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
+            "id": _id,
+            "delmalApiNavn": apiNavn,
+            "delmalNavn": visningsnavn,
+            gruppeVisningsnavn,
+            "delmalFlettefelter": 
+                    ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ]{
+                        "flettefelt": markDefs[].flettefeltReferanse
+                      },
+            "delmalValgfelt": ${maalform}[defined(valgReferanse)].valgReferanse ->{
+                    "valgfeltVisningsnavn":visningsnavn,
+                    "valgFeltApiNavn": apiNavn,
+                    "valgfeltBeskrivelse": beskrivelse,
+                    "valgMuligheter":
+                        valg[]{
+                            valgmulighet,
+                            "visningsnavnValgmulighet": delmal->.visningsnavn,
+                            "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
+                                 "flettefelt": markDefs[].flettefeltReferanse 
+                            }  
+                        }
+            }
+        },
+        "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
+            _type,
+            "innhold": select(
+                _type == "fritekstområde" => { "id": _key },
+                defined(delmalReferanse) => delmalReferanse->{
+                  "delmalApiNavn": apiNavn,
+                  "delmalNavn": visningsnavn,
+                  gruppeVisningsnavn,
+                  "delmalFlettefelter": 
+                          ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ] {
+                              "flettefelt": markDefs[].flettefeltReferanse
+                          },
+                  "delmalValgfelt":  ^.${maalform}[defined(valgReferanse)].valgReferanse ->{
+                          "valgfeltVisningsnavn":visningsnavn,
+                          "valgFeltApiNavn": apiNavn,
+                          "valgfeltBeskrivelse": beskrivelse,
+                          "valgMuligheter":
+                              valg[]{
+                                  valgmulighet,
+                                  "visningsnavnValgmulighet": delmal->.visningsnavn,
+                                  "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
+                                       "flettefelt": markDefs[].flettefeltReferanse 
+                                  }  
+                              }
+                  }
+                }
+            )
+        }
+  }[0]`;
+
+  return clientV2(datasett, '2022-03-07')
     .fetch(query)
     .catch(error => {
       throw new Feil(error.message, error.statusCode);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -15,7 +15,11 @@ import { Feil } from './utils/Feil';
 import hentAvansertDokumentHtml from './hentAvansertDokumentHtml';
 import validerDokumentApiData from './utils/valideringer/validerDokumentApiData';
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
-import { hentAvansertDokumentFelter, hentFlettefelter } from './hentAvansertDokumentFelter';
+import {
+  hentAvansertDokumentFelter,
+  hentAvansertDokumentFelter_V20220307,
+  hentFlettefelter,
+} from './hentAvansertDokumentFelter';
 import { hentAvansertDokumentNavn } from './hentAvansertDokumentNavn';
 import { lagManueltBrevHtml } from './lagManueltBrevHtml';
 import { genererSøknadHtml } from './søknadgenerator';
@@ -133,6 +137,29 @@ router.get(
         res.status(err.code).send(`Henting av felter feilet: ${err.message}`);
       },
     );
+
+    const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
+      res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
+    });
+    logFerdigstilt(req);
+    res.send({ data: { dokument: felter, flettefelter }, status: 'SUKSESS' });
+  },
+);
+
+router.get(
+  '/:datasett/avansert-dokument/:maalform/:dokumentApiNavn/felter_v2',
+  async (req: Request, res: Response) => {
+    const datasett = req.params.datasett as Datasett;
+    const maalform = req.params.maalform as Maalform;
+    const avansertDokumentNavn = req.params.dokumentApiNavn;
+
+    const felter = await hentAvansertDokumentFelter_V20220307(
+      datasett,
+      maalform,
+      avansertDokumentNavn,
+    ).catch(err => {
+      res.status(err.code).send(`Henting av felter feilet: ${err.message}`);
+    });
 
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -147,7 +147,7 @@ router.get(
 );
 
 router.get(
-  '/:datasett/avansert-dokument/:maalform/:dokumentApiNavn/felter_v2',
+  '/:datasett/avansert-dokument/:maalform/:dokumentApiNavn/felter/v2',
   async (req: Request, res: Response) => {
     const datasett = req.params.datasett as Datasett;
     const maalform = req.params.maalform as Maalform;

--- a/src/server/sanity/sanityClient.ts
+++ b/src/server/sanity/sanityClient.ts
@@ -20,3 +20,12 @@ export const client = (dataset: Datasett) =>
     useCdn: NODE_ENV == 'production' || NODE_ENV == 'preprod',
     maxRetries: 3,
   });
+
+export const clientV2 = (dataset: Datasett, apiVersion: string) =>
+  createClient({
+    projectId: 'xsrv1mh6',
+    dataset,
+    useCdn: NODE_ENV == 'production' || NODE_ENV == 'preprod',
+    maxRetries: 3,
+    apiVersion: apiVersion,
+  });


### PR DESCRIPTION
Vil legge til nytt endepunkt som bruker nyere versjon av sanity api. Nå bruker vi versjon 1. Legger derfor til ny klient med støtte for å angi versjon (default er v1).

Bytter i første omgang bare ett endepunk brukt av EF (hentAvansertDokumentFelter). 

Må oppdatere groq query. 

(vil legge til toggle for bruk av nytt endepunkt i ef-sak-frontend) 
Testet lokalt. Ser greit ut, men vil gjerne teste dette grundig - vanskelig å være sikker på at alt er som før her. 

Groq queries i sanity studio (vision) ser ut til å returnere samme json. 
