### PR TITLE
Forenkling groq

### DIFF
--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -23,10 +23,10 @@ export interface ValgFelt {
   valgfeltBeskrivelse?: string;
 }
 
-export interface Delmaler {
-  delmalarray: Delmal[];
+export interface Root {
+  delmalerSortert: DelmalerSortert[];
 }
-export interface Delmal {
+export interface DelmalerSortert {
   delmalApiNavn: string;
   delmalNavn: string;
   delmalValgfelt: ValgFelt[];
@@ -35,7 +35,7 @@ export interface Delmal {
 }
 
 export interface DokumentMal {
-  delmalerSortert: Delmal[];
+  delmalerSortert: DelmalerSortert[];
   brevmenyBlokker: BrevmenyBlokk[];
 }
 
@@ -45,7 +45,7 @@ export type FritekstBlokk = {
 };
 type DelmalBlokk = {
   _type: 'delmalBlock';
-  innhold: Delmal;
+  innhold: DelmalerSortert;
 };
 export type BrevmenyBlokker = {
   brevmenyBlokker: BrevmenyBlokk[];
@@ -89,7 +89,7 @@ export const hentDelmalerSortert = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<Delmaler> => {
+): Promise<Root> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
             "delmalApiNavn": apiNavn,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -65,7 +65,7 @@ export const hentBrevstruktur = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<DokumentMal> => {
+): Promise<string> => {
   const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
     datasett,
     maalform,
@@ -76,8 +76,8 @@ export const hentBrevstruktur = async (
     maalform,
     avansertDokumentNavn,
   );
-  const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
-  return dokumentMal;
+
+  return JSON.stringify(delmalerSortert) + JSON.stringify(brevmenyBlokker);
 };
 
 const hentDelmalerSortert = async (

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -23,6 +23,9 @@ export interface ValgFelt {
   valgfeltBeskrivelse?: string;
 }
 
+export interface Delmaler {
+  delmalarray: Delmal[];
+}
 export interface Delmal {
   delmalApiNavn: string;
   delmalNavn: string;
@@ -44,7 +47,9 @@ type DelmalBlokk = {
   _type: 'delmalBlock';
   innhold: Delmal;
 };
-
+export type BrevmenyBlokker = {
+  brevmenyBlokker: BrevmenyBlokk[];
+};
 export type BrevmenyBlokk = FritekstBlokk | DelmalBlokk;
 
 export const hentFlettefelter = async (
@@ -61,30 +66,30 @@ export const hentFlettefelter = async (
     });
 };
 
-export const hentBrevstruktur = async (
-  datasett: Datasett,
-  maalform: Maalform,
-  avansertDokumentNavn: string,
-): Promise<DokumentMal> => {
-  const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
-    datasett,
-    maalform,
-    avansertDokumentNavn,
-  );
-  const delmalerSortert: Delmal[] = await hentDelmalerSortert(
-    datasett,
-    maalform,
-    avansertDokumentNavn,
-  );
-  const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
-  return dokumentMal;
-};
+// export const hentBrevstruktur = async (
+//   datasett: Datasett,
+//   maalform: Maalform,
+//   avansertDokumentNavn: string,
+// ): Promise<DokumentMal> => {
+//   const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
+//     datasett,
+//     maalform,
+//     avansertDokumentNavn,
+//   );
+//   const delmalerSortert: Delmaler = await hentDelmalerSortert(
+//     datasett,
+//     maalform,
+//     avansertDokumentNavn,
+//   );
+//   const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
+//   return dokumentMal;
+// };
 
 export const hentDelmalerSortert = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<Delmal[]> => {
+): Promise<Delmaler> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
             "delmalApiNavn": apiNavn,
@@ -120,7 +125,7 @@ export const hentBrevmenyBlokker = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<BrevmenyBlokk[]> => {
+): Promise<BrevmenyBlokker> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
             _type,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -47,7 +47,7 @@ type DelmalBlokk = {
   _type: 'delmalBlock';
   innhold: DelmalerSortert;
 };
-export type BrevmenyBlokker = {
+export type Brevmeny = {
   brevmenyBlokker: BrevmenyBlokk[];
 };
 export type BrevmenyBlokk = FritekstBlokk | DelmalBlokk;
@@ -65,25 +65,6 @@ export const hentFlettefelter = async (
       throw new Feil(error.message, error.statusCode);
     });
 };
-
-// export const hentBrevstruktur = async (
-//   datasett: Datasett,
-//   maalform: Maalform,
-//   avansertDokumentNavn: string,
-// ): Promise<DokumentMal> => {
-//   const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
-//     datasett,
-//     maalform,
-//     avansertDokumentNavn,
-//   );
-//   const delmalerSortert: Delmaler = await hentDelmalerSortert(
-//     datasett,
-//     maalform,
-//     avansertDokumentNavn,
-//   );
-//   const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
-//   return dokumentMal;
-// };
 
 export const hentDelmalerSortert = async (
   datasett: Datasett,
@@ -125,7 +106,7 @@ export const hentBrevmenyBlokker = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<BrevmenyBlokker> => {
+): Promise<Brevmeny> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
             _type,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -23,7 +23,7 @@ export interface ValgFelt {
   valgfeltBeskrivelse?: string;
 }
 
-export interface Root {
+export interface Delmaler {
   delmalerSortert: DelmalerSortert[];
 }
 export interface DelmalerSortert {
@@ -89,7 +89,7 @@ export const hentDelmalerSortert = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<Root> => {
+): Promise<Delmaler> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
             "delmalApiNavn": apiNavn,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -16,6 +16,85 @@ export const hentFlettefelter = async (
     });
 };
 
+export const hentDelmalerSortert = async (
+  datasett: Datasett,
+  maalform: Maalform,
+  avansertDokumentNavn: string,
+): Promise<string> => {
+  const query = `*[apiNavn == "${avansertDokumentNavn}"]{
+        "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
+            "delmalApiNavn": apiNavn,
+            "delmalNavn": visningsnavn,
+            gruppeVisningsnavn,
+            "delmalFlettefelter": 
+                    ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ]{
+                        "flettefelt": markDefs[].flettefeltReferanse
+                      },
+            "delmalValgfelt": ${maalform}[defined(valgReferanse)].valgReferanse ->{
+                    "valgfeltVisningsnavn":visningsnavn,
+                    "valgFeltApiNavn": apiNavn,
+                    "valgfeltBeskrivelse": beskrivelse,
+                    "valgMuligheter":
+                        valg[]{
+                            valgmulighet,
+                            "visningsnavnValgmulighet": delmal->.visningsnavn,
+                            "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
+                                 "flettefelt": markDefs[].flettefeltReferanse 
+                            }  
+                        }
+            }
+        }
+  }[0]`;
+  return clientV2(datasett, '2022-03-07')
+    .fetch(query)
+    .catch(error => {
+      throw new Feil(error.message, error.statusCode);
+    });
+};
+
+export const hentBrevmenyBlokker = async (
+  datasett: Datasett,
+  maalform: Maalform,
+  avansertDokumentNavn: string,
+): Promise<string> => {
+  const query = `*[apiNavn == "${avansertDokumentNavn}"]{
+        "brevmenyBlokker": ${maalform}[defined(delmalReferanse) ||  _type == "fritekstområde" ] | { 
+            _type,
+            "innhold": select(
+                _type == "fritekstområde" => { "id": _key },
+                defined(delmalReferanse) => delmalReferanse->{
+                  "delmalApiNavn": apiNavn,
+                  "delmalNavn": visningsnavn,
+                  gruppeVisningsnavn,
+                  "delmalFlettefelter": 
+                          ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ] {
+                              "flettefelt": markDefs[].flettefeltReferanse
+                          },
+                  "delmalValgfelt":  ${maalform}[defined(valgReferanse)].valgReferanse ->{
+                          "valgfeltVisningsnavn":visningsnavn,
+                          "valgFeltApiNavn": apiNavn,
+                          "valgfeltBeskrivelse": beskrivelse,
+                          "valgMuligheter":
+                              valg[]{
+                                  valgmulighet,
+                                  "visningsnavnValgmulighet": delmal->.visningsnavn,
+                                  "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
+                                       "flettefelt": markDefs[].flettefeltReferanse 
+                                  }  
+                              }
+                  }
+                }
+            )
+        }
+  }[0]`;
+
+  return clientV2(datasett, '2022-03-07')
+    .fetch(query)
+    .catch(error => {
+      throw new Feil(error.message, error.statusCode);
+    });
+};
+
 export const hentAvansertDokumentFelter_V20220307 = async (
   datasett: Datasett,
   maalform: Maalform,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -80,7 +80,7 @@ export const hentBrevstruktur = async (
   return dokumentMal;
 };
 
-const hentDelmalerSortert = async (
+export const hentDelmalerSortert = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
@@ -116,7 +116,7 @@ const hentDelmalerSortert = async (
     });
 };
 
-const hentBrevmenyBlokker = async (
+export const hentBrevmenyBlokker = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -23,9 +23,6 @@ export interface ValgFelt {
   valgfeltBeskrivelse?: string;
 }
 
-export interface Delmaler {
-  delmalerSortert: DelmalerSortert[];
-}
 export interface DelmalerSortert {
   delmalApiNavn: string;
   delmalNavn: string;
@@ -40,7 +37,6 @@ export interface BrevStruktur {
 }
 
 export interface DokumentMal {
-  //delmalerSortert: DelmalerSortert[];
   brevmenyBlokker: BrevmenyBlokk[];
 }
 
@@ -96,42 +92,6 @@ export const hentFlettefelterMedType = async (
       throw new Feil(error.message, error.statusCode);
     });
 };
-
-// export const hentDelmalerSortert = async (
-//   datasett: Datasett,
-//   maalform: Maalform,
-//   avansertDokumentNavn: string,
-// ): Promise<Delmaler> => {
-//   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
-//         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{
-//             "delmalApiNavn": apiNavn,
-//             "delmalNavn": visningsnavn,
-//             gruppeVisningsnavn,
-//             "delmalFlettefelter":
-//                     ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ]{
-//                         "flettefelt": markDefs[].flettefeltReferanse
-//                       },
-//             "delmalValgfelt": ${maalform}[defined(valgReferanse)].valgReferanse ->{
-//                     "valgfeltVisningsnavn":visningsnavn,
-//                     "valgFeltApiNavn": apiNavn,
-//                     "valgfeltBeskrivelse": beskrivelse,
-//                     "valgMuligheter":
-//                         valg[]{
-//                             valgmulighet,
-//                             "visningsnavnValgmulighet": delmal->.visningsnavn,
-//                             "flettefelter": delmal-> ${maalform}[defined(markDefs)] {
-//                                  "flettefelt": markDefs[].flettefeltReferanse
-//                             }
-//                         }
-//             }
-//         }
-//   }[0]`;
-//   return clientV2(datasett, '2022-03-07')
-//     .fetch(query)
-//     .catch(error => {
-//       throw new Feil(error.message, error.statusCode);
-//     });
-// };
 
 export const hentBrevmenyBlokker = async (
   datasett: Datasett,

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -66,9 +66,18 @@ export const hentBrevstruktur = async (
   maalform: Maalform,
   avansertDokumentNavn: string,
 ): Promise<DokumentMal> => {
-  const brevmenyBlokker = await hentBrevmenyBlokker(datasett, maalform, avansertDokumentNavn);
-  const delmalerSortert = await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn);
-  return { delmalerSortert, brevmenyBlokker };
+  const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
+    datasett,
+    maalform,
+    avansertDokumentNavn,
+  );
+  const delmalerSortert: Delmal[] = await hentDelmalerSortert(
+    datasett,
+    maalform,
+    avansertDokumentNavn,
+  );
+  const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
+  return dokumentMal;
 };
 
 const hentDelmalerSortert = async (

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -65,7 +65,7 @@ export const hentBrevstruktur = async (
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<string> => {
+): Promise<DokumentMal> => {
   const brevmenyBlokker: BrevmenyBlokk[] = await hentBrevmenyBlokker(
     datasett,
     maalform,
@@ -76,8 +76,8 @@ export const hentBrevstruktur = async (
     maalform,
     avansertDokumentNavn,
   );
-
-  return JSON.stringify(delmalerSortert) + JSON.stringify(brevmenyBlokker);
+  const dokumentMal: DokumentMal = { delmalerSortert, brevmenyBlokker };
+  return dokumentMal;
 };
 
 const hentDelmalerSortert = async (

--- a/src/server/hentAvansertDokumentFelter.ts
+++ b/src/server/hentAvansertDokumentFelter.ts
@@ -34,9 +34,26 @@ export interface DelmalerSortert {
   gruppeVisningsnavn: string;
 }
 
+export interface BrevStruktur {
+  dokument: DokumentMal;
+  flettefelter: AlleFlettefelter;
+}
+
 export interface DokumentMal {
-  delmalerSortert: DelmalerSortert[];
+  //delmalerSortert: DelmalerSortert[];
   brevmenyBlokker: BrevmenyBlokk[];
+}
+
+export interface AlleFlettefelter {
+  flettefeltReferanse: Flettefelt[];
+}
+
+interface Flettefelt {
+  felt: string;
+  erFritektsfelt?: boolean;
+  feltVisningsnavn?: string;
+  _id: string;
+  beskrivelse?: string;
 }
 
 export type FritekstBlokk = {
@@ -66,41 +83,55 @@ export const hentFlettefelter = async (
     });
 };
 
-export const hentDelmalerSortert = async (
+export const hentFlettefelterMedType = async (
   datasett: Datasett,
-  maalform: Maalform,
   avansertDokumentNavn: string,
-): Promise<Delmaler> => {
+): Promise<AlleFlettefelter> => {
   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
-        "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{ 
-            "delmalApiNavn": apiNavn,
-            "delmalNavn": visningsnavn,
-            gruppeVisningsnavn,
-            "delmalFlettefelter": 
-                    ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ]{
-                        "flettefelt": markDefs[].flettefeltReferanse
-                      },
-            "delmalValgfelt": ${maalform}[defined(valgReferanse)].valgReferanse ->{
-                    "valgfeltVisningsnavn":visningsnavn,
-                    "valgFeltApiNavn": apiNavn,
-                    "valgfeltBeskrivelse": beskrivelse,
-                    "valgMuligheter":
-                        valg[]{
-                            valgmulighet,
-                            "visningsnavnValgmulighet": delmal->.visningsnavn,
-                            "flettefelter": delmal-> ${maalform}[defined(markDefs)] {           
-                                 "flettefelt": markDefs[].flettefeltReferanse 
-                            }  
-                        }
-            }
-        }
-  }[0]`;
-  return clientV2(datasett, '2022-03-07')
+     "flettefeltReferanse" :  *[ _type=='flettefelt' ]
+    }[0]`;
+  return client(datasett)
     .fetch(query)
     .catch(error => {
       throw new Feil(error.message, error.statusCode);
     });
 };
+
+// export const hentDelmalerSortert = async (
+//   datasett: Datasett,
+//   maalform: Maalform,
+//   avansertDokumentNavn: string,
+// ): Promise<Delmaler> => {
+//   const query = `*[apiNavn == "${avansertDokumentNavn}"]{
+//         "delmalerSortert": ${maalform}[defined(delmalReferanse)].delmalReferanse->{
+//             "delmalApiNavn": apiNavn,
+//             "delmalNavn": visningsnavn,
+//             gruppeVisningsnavn,
+//             "delmalFlettefelter":
+//                     ${maalform}[length(markDefs[].flettefeltReferanse) > 0 ]{
+//                         "flettefelt": markDefs[].flettefeltReferanse
+//                       },
+//             "delmalValgfelt": ${maalform}[defined(valgReferanse)].valgReferanse ->{
+//                     "valgfeltVisningsnavn":visningsnavn,
+//                     "valgFeltApiNavn": apiNavn,
+//                     "valgfeltBeskrivelse": beskrivelse,
+//                     "valgMuligheter":
+//                         valg[]{
+//                             valgmulighet,
+//                             "visningsnavnValgmulighet": delmal->.visningsnavn,
+//                             "flettefelter": delmal-> ${maalform}[defined(markDefs)] {
+//                                  "flettefelt": markDefs[].flettefeltReferanse
+//                             }
+//                         }
+//             }
+//         }
+//   }[0]`;
+//   return clientV2(datasett, '2022-03-07')
+//     .fetch(query)
+//     .catch(error => {
+//       throw new Feil(error.message, error.statusCode);
+//     });
+// };
 
 export const hentBrevmenyBlokker = async (
   datasett: Datasett,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -17,7 +17,6 @@ import hentAvansertDokumentHtml from './hentAvansertDokumentHtml';
 import validerDokumentApiData from './utils/valideringer/validerDokumentApiData';
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import {
-  DokumentMal,
   hentAvansertDokumentFelter,
   hentAvansertDokumentFelter_V20220307,
   hentBrevstruktur,
@@ -182,13 +181,11 @@ router.get(
     const maalform = req.params.maalform as Maalform;
     const avansertDokumentNavn = req.params.dokumentApiNavn;
 
-    const brevstruktur: void | DokumentMal = await hentBrevstruktur(
-      datasett,
-      maalform,
-      avansertDokumentNavn,
-    ).catch(err => {
-      res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
-    });
+    const brevstruktur = await hentBrevstruktur(datasett, maalform, avansertDokumentNavn).catch(
+      err => {
+        res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
+      },
+    );
 
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
@@ -197,7 +194,7 @@ router.get(
     logFerdigstilt(req);
 
     const json = {
-      data: { dokument: JSON.stringify(brevstruktur), flettefelter },
+      data: { dokument: brevstruktur, flettefelter },
       status: 'SUKSESS',
     };
     res.send(json);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20,7 +20,9 @@ import {
   DokumentMal,
   hentAvansertDokumentFelter,
   hentAvansertDokumentFelter_V20220307,
+  hentBrevmenyBlokker,
   hentBrevstruktur,
+  hentDelmalerSortert,
   hentFlettefelter,
 } from './hentAvansertDokumentFelter';
 import { hentAvansertDokumentNavn } from './hentAvansertDokumentNavn';
@@ -190,14 +192,34 @@ router.get(
       res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
     });
 
+    const brevmeny = await hentBrevmenyBlokker(datasett, maalform, avansertDokumentNavn).catch(
+      err => {
+        res.status(err.code).send(`Henting av brevmenyblokker feilet: ${err.message}`);
+      },
+    );
+
+    const delmaler = await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn).catch(
+      err => {
+        res.status(err.code).send(`Henting av delmaler feilet: ${err.message}`);
+      },
+    );
+
+    logInfo(` Brevmeny: [${brevmeny}]`);
+    logInfo(`Delmaler: [${delmaler}] `);
+
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
     });
 
     logFerdigstilt(req);
 
+    const mal: DokumentMal = { delmalerSortert: delmaler!, brevmenyBlokker: brevmeny! };
+
+    logInfo(`Mal: [${mal}]`);
+    logInfo(`Brevstruktur: [${brevstruktur}]`);
+
     const json = {
-      data: { dokument: brevstruktur, flettefelter },
+      data: { dokument: mal, flettefelter },
       status: 'SUKSESS',
     };
     res.send(json);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import express from 'express';
 import type { Datasett } from './sanity/sanityClient';
 import type { Maalform } from '../typer/sanitygrensesnitt';
+//import type { DokumentMal } from './hentAvansertDokumentFelter';
 import type {
   IAvansertDokumentVariabler,
   IBrevMedSignatur,
@@ -18,8 +19,7 @@ import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import {
   hentAvansertDokumentFelter,
   hentAvansertDokumentFelter_V20220307,
-  hentBrevmenyBlokker,
-  hentDelmalerSortert,
+  hentBrevstruktur,
   hentFlettefelter,
 } from './hentAvansertDokumentFelter';
 import { hentAvansertDokumentNavn } from './hentAvansertDokumentNavn';
@@ -181,23 +181,20 @@ router.get(
     const maalform = req.params.maalform as Maalform;
     const avansertDokumentNavn = req.params.dokumentApiNavn;
 
-    const brevmeny = await hentBrevmenyBlokker(datasett, maalform, avansertDokumentNavn).catch(
+    const brevstruktur = await hentBrevstruktur(datasett, maalform, avansertDokumentNavn).catch(
       err => {
-        res.status(err.code).send(`Henting av brevmenyblokker feilet: ${err.message}`);
-      },
-    );
-
-    const delmaler = await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn).catch(
-      err => {
-        res.status(err.code).send(`Henting av delmaler feilet: ${err.message}`);
+        res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
       },
     );
 
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
     });
+
     logFerdigstilt(req);
-    res.send({ data: { dokument: brevmeny, delmaler, flettefelter }, status: 'SUKSESS' });
+
+    const json = { data: { dokument: brevstruktur, flettefelter }, status: 'SUKSESS' };
+    res.send(json);
   },
 );
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -17,6 +17,7 @@ import hentAvansertDokumentHtml from './hentAvansertDokumentHtml';
 import validerDokumentApiData from './utils/valideringer/validerDokumentApiData';
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import {
+  DokumentMal,
   hentAvansertDokumentFelter,
   hentAvansertDokumentFelter_V20220307,
   hentBrevstruktur,
@@ -181,11 +182,13 @@ router.get(
     const maalform = req.params.maalform as Maalform;
     const avansertDokumentNavn = req.params.dokumentApiNavn;
 
-    const brevstruktur = await hentBrevstruktur(datasett, maalform, avansertDokumentNavn).catch(
-      err => {
-        res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
-      },
-    );
+    const brevstruktur: void | DokumentMal = await hentBrevstruktur(
+      datasett,
+      maalform,
+      avansertDokumentNavn,
+    ).catch(err => {
+      res.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
+    });
 
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -196,7 +196,10 @@ router.get(
 
     logFerdigstilt(req);
 
-    const json = { data: { dokument: brevstruktur, flettefelter }, status: 'SUKSESS' };
+    const json = {
+      data: { dokument: JSON.stringify(brevstruktur), flettefelter },
+      status: 'SUKSESS',
+    };
     res.send(json);
   },
 );

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -197,11 +197,14 @@ router.get(
     const maalform = req.params.maalform as Maalform;
     const avansertDokumentNavn = req.params.dokumentApiNavn;
 
-    // TODO hva med feilhåndtering?
-    const returData = await hentBrevStruktur(datasett, maalform, avansertDokumentNavn);
-    const responseData: RessursSuksess<BrevStruktur> = { data: returData, status: 'SUKSESS' };
-
-    response.send(responseData);
+    hentBrevStruktur(datasett, maalform, avansertDokumentNavn)
+      .then(returData => {
+        const responseData: RessursSuksess<BrevStruktur> = { data: returData, status: 'SUKSESS' };
+        response.send(responseData);
+      })
+      .catch(err => {
+        response.status(err.code).send(`Henting av brevstruktur feilet: ${err.message}`);
+      });
   },
 );
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -18,7 +18,7 @@ import validerDokumentApiData from './utils/valideringer/validerDokumentApiData'
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import {
   BrevmenyBlokker,
-  Delmaler,
+  Root,
   DokumentMal,
   hentAvansertDokumentFelter,
   hentAvansertDokumentFelter_V20220307,
@@ -191,22 +191,23 @@ router.get(
       avansertDokumentNavn,
     );
 
-    const delmaler: Delmaler = await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn);
+    const delmaler: Root = await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn);
 
     logInfo(` Brevmeny: ${brevmeny.brevmenyBlokker}`);
-    logInfo(`Delmaler: ${delmaler.delmalarray} `);
+    logInfo(`DelmalerSortert: ${delmaler.delmalerSortert} `);
+    logInfo(`Delmaler: ${delmaler} `);
 
     const flettefelter = await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
       res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
     });
 
     const dokumentMal: DokumentMal = {
-      delmalerSortert: delmaler.delmalarray,
+      delmalerSortert: delmaler.delmalerSortert,
       brevmenyBlokker: brevmeny.brevmenyBlokker,
     };
 
     const json = {
-      data: { dokumentMal, flettefelter },
+      data: { dokument: dokumentMal, flettefelter },
       status: 'SUKSESS',
     };
     res.send(json);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2,7 +2,6 @@ import type { Request, Response } from 'express';
 import express from 'express';
 import type { Datasett } from './sanity/sanityClient';
 import type { Maalform } from '../typer/sanitygrensesnitt';
-//import type { DokumentMal } from './hentAvansertDokumentFelter';
 import type {
   IAvansertDokumentVariabler,
   IBrevMedSignatur,
@@ -17,7 +16,7 @@ import hentAvansertDokumentHtml from './hentAvansertDokumentHtml';
 import validerDokumentApiData from './utils/valideringer/validerDokumentApiData';
 import { logError, logInfo, logSecure } from '@navikt/familie-logging';
 import {
-  BrevmenyBlokker,
+  Brevmeny,
   Delmaler,
   DokumentMal,
   hentAvansertDokumentFelter,
@@ -181,7 +180,7 @@ router.get(
 async function hentAlleFlettefelter(
   datasett: Datasett,
   avansertDokumentNavn: string,
-  res: e.Response<any, Record<string, any>>,
+  res: Response<any, Record<string, any>>,
 ) {
   return await hentFlettefelter(datasett, avansertDokumentNavn).catch(err => {
     res.status(err.code).send(`Henting av flettefelter feilet: ${err.message}`);
@@ -193,7 +192,7 @@ async function hentDelmaler(
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-  res: e.Response<any, Record<string, any>>,
+  res: Response<any, Record<string, any>>,
 ) {
   return await hentDelmalerSortert(datasett, maalform, avansertDokumentNavn).catch(err => {
     res.status(err.code).send(`Henting av delmaler feilet: ${err.message}`);
@@ -205,7 +204,7 @@ async function hentBrevmeny(
   datasett: Datasett,
   maalform: Maalform,
   avansertDokumentNavn: string,
-  res: e.Response<any, Record<string, any>>,
+  res: Response<any, Record<string, any>>,
 ) {
   return await hentBrevmenyBlokker(datasett, maalform, avansertDokumentNavn).catch(err => {
     res.status(err.code).send(`Henting av brevmeny feilet: ${err.message}`);
@@ -220,12 +219,7 @@ router.get(
     const maalform = req.params.maalform as Maalform;
     const avansertDokumentNavn = req.params.dokumentApiNavn;
 
-    const brevmeny: BrevmenyBlokker = await hentBrevmeny(
-      datasett,
-      maalform,
-      avansertDokumentNavn,
-      res,
-    );
+    const brevmeny: Brevmeny = await hentBrevmeny(datasett, maalform, avansertDokumentNavn, res);
     const delmaler: Delmaler = await hentDelmaler(datasett, maalform, avansertDokumentNavn, res);
     const flettefelter = await hentAlleFlettefelter(datasett, avansertDokumentNavn, res);
 
@@ -261,7 +255,7 @@ router.get(
 
     const navn = await hentAvansertDokumentNavn(datasett, hentUpubliserte).catch(err => {
       res.status(err.code).send(`Henting av avanserte dokumenter feilet: ${err.message}`);
-      return '';
+      return;
     });
 
     logFerdigstilt(req);


### PR DESCRIPTION
Poc - forenkling og typing. Fortsette, eller tenke annerledes? 

relatert til poc ef-sak-frontend
https://github.com/navikt/familie-ef-sak-frontend/pull/2937
som da gjør at vi kan droppe hele denne delen av groq: 
(router)
    const delmaler: Delmaler = await hentDelmaler(datasett, maalform, avansertDokumentNavn, res);