### PR TITLE
Splitt fritekst på linjeskift

### DIFF
--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -2,6 +2,7 @@ import type { Flettefelter } from '../../../typer/dokumentApiBrev';
 import React from 'react';
 import { Feil } from '../../utils/Feil';
 import { validerFlettefelt } from '../../utils/valideringer/validerFlettefelt';
+import { styled } from 'styled-components';
 
 interface IFlettefeltSerializerProps {
   sanityProps: any;
@@ -10,10 +11,15 @@ interface IFlettefeltSerializerProps {
   erListe?: boolean;
 }
 
+const StyledParagraph = styled.p`
+  white-space: pre-wrap;
+`;
+
 export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
   const { sanityProps, flettefelter, dokumentApiNavn, erListe } = props;
   const flettefeltNavn = hentFlettefeltNavn(sanityProps);
   const erFlettefeltListe = hentFlettefeltErListe(sanityProps, erListe);
+  const erFlettefeltFritekstfelt = hentFlettefeltErFritekstfelt(sanityProps);
 
   if (!flettefelter) {
     throw new Feil(
@@ -42,6 +48,14 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
         ))}
       </ul>
     );
+  } else if (erFlettefeltFritekstfelt) {
+    return (
+      <span className={høyrestill ? 'høyrestill' : ''}>
+        {flettefelt[0].split('\n\n').map((avsnitt, index) => (
+          <StyledParagraph key={index}>{avsnitt}</StyledParagraph>
+        ))}
+      </span>
+    );
   } else {
     return <span className={høyrestill ? 'høyrestill' : ''}>{flettefelt[0]}</span>;
   }
@@ -58,4 +72,8 @@ const hentFlettefeltNavn = (sanityProps: any) => {
 const hentFlettefeltErListe = (sanityProps: any, erBegrunnelse?: boolean) => {
   const { flettefeltReferanse } = sanityProps.value;
   return !!(flettefeltReferanse?.erListe || erBegrunnelse);
+};
+
+const hentFlettefeltErFritekstfelt = (sanityProps: any) => {
+  return sanityProps.value.flettefeltReferanse?.erFritektsfelt == true;
 };


### PR DESCRIPTION
Dersom "Er fritekstfelt" er huket av for et flettefelt i Sanity, splittes teksten på `\n\n` og puttes i egne paragraph tags, slik at de kommer på ny linje i PDF'en