### PR TITLE
Lag næringsinntekt notat

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,7 +25,7 @@ app.use('/api', routes);
 app.use('/ba-sak', baSakEndepunkter);
 app.use('/ks-sak', ksSakEndepunkter);
 app.use('/blankett', blankettRoutes);
-app.use('/næringsinntekt-kontroll', næringsinntektRoutes);
+app.use('/naeringsinntekt-kontroll', næringsinntektRoutes);
 
 const port = 8001;
 app.listen(port, () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import baSakEndepunkter from '../baks/baSakEndepunkter';
 import dotenv from 'dotenv';
 import { logInfo } from '@navikt/familie-logging';
 import blankettRoutes from './blankett/blankettRoutes';
+import næringsinntektRoutes from './næringsinntekt/næringsinntektRoutes';
 
 dotenv.config();
 export const { NODE_ENV } = process.env;
@@ -24,6 +25,7 @@ app.use('/api', routes);
 app.use('/ba-sak', baSakEndepunkter);
 app.use('/ks-sak', ksSakEndepunkter);
 app.use('/blankett', blankettRoutes);
+app.use('/næringsinntekt-kontroll', næringsinntektRoutes);
 
 const port = 8001;
 app.listen(port, () => {

--- a/src/server/mock/dummyDataNæringsinntekt.json
+++ b/src/server/mock/dummyDataNæringsinntekt.json
@@ -1,0 +1,11 @@
+{
+  "saksid": "12345",
+  "personIdent": "01010199999",
+  "navn": "Navn",
+  "saksbehandlernavn": "saksbehandlernavn",
+  "enhet": "enhet",
+  "forventetInntekt": 100000,
+  "næringsinntekt": 50000,
+  "personinntekt": 60000,
+  "årstall": 2023
+}

--- a/src/server/næringsinntekt/components/Header.tsx
+++ b/src/server/næringsinntekt/components/Header.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { css, styled } from 'styled-components';
+
+interface HeaderProps {
+  personident: string;
+  navn: string;
+  saksbehandlernavn: string;
+  enhet: string;
+  tittel: string;
+  årstall: number;
+}
+
+const CommonCellCSS = css`
+  border: none;
+  display: table-cell;
+  padding: 0.25rem 0.5rem;
+  font-family:
+    Source Sans Pro,
+    sans-serif;
+  font-size: 12pt;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  margin: 0;
+  border-bottom: 1px solid #838c9a;
+`;
+
+const StyledTableData = styled.td<{ $borderTop?: boolean }>`
+  ${CommonCellCSS};
+  font-weight: 400;
+`;
+
+const StyledTableHeader = styled.th`
+  ${CommonCellCSS};
+  border-bottom: 2px solid #838c9a;
+  font-weight: 600;
+`;
+
+const StyledTableDataRow = styled.tr<{ $borderTop?: boolean }>`
+    ${StyledTableData} {
+        border-top: ${props => (props.$borderTop ? '2px solid #838c9a' : 'none')};
+    }
+}
+`;
+
+export function Header(props: HeaderProps) {
+  const { personident, navn, saksbehandlernavn, enhet, tittel, årstall } = props;
+
+  return (
+    <div>
+      <h1>{tittel}</h1>
+      <StyledTableData>
+        <StyledTableHeader>Saksnummer: GENERELL_SAK</StyledTableHeader>
+        <StyledTableDataRow>
+          <StyledTableData>
+            <b>Hvem saken gjelder</b>
+          </StyledTableData>
+          <StyledTableData>Navn: {navn}</StyledTableData>
+          <StyledTableData>Fødselsnummer: {personident}</StyledTableData>
+        </StyledTableDataRow>
+        <StyledTableDataRow>
+          <StyledTableData>
+            <b>Saksbehandler(e)</b>
+          </StyledTableData>
+          <StyledTableData>Navn: {saksbehandlernavn}</StyledTableData>
+          <StyledTableData>Enhet: {enhet}</StyledTableData>
+        </StyledTableDataRow>
+        <StyledTableDataRow>
+          <StyledTableData>Saken gjelder:</StyledTableData>
+          <StyledTableData>Vurdering næringsinntekt {årstall}</StyledTableData>
+        </StyledTableDataRow>
+      </StyledTableData>
+    </div>
+  );
+}

--- a/src/server/næringsinntekt/components/Header.tsx
+++ b/src/server/næringsinntekt/components/Header.tsx
@@ -1,27 +1,25 @@
 import React from 'react';
 import { css, styled } from 'styled-components';
+import { dagensDatoFormatert } from '../../utils/util';
 
 interface HeaderProps {
+  saksid: string;
   personident: string;
   navn: string;
   saksbehandlernavn: string;
   enhet: string;
-  tittel: string;
   årstall: number;
 }
 
 const CommonCellCSS = css`
-  border: none;
   display: table-cell;
-  padding: 0.25rem 0.5rem;
   font-family:
     Source Sans Pro,
     sans-serif;
   font-size: 12pt;
   letter-spacing: 0;
-  line-height: 1.5rem;
   margin: 0;
-  border-bottom: 1px solid #838c9a;
+  border: 1px solid #838c9a;
 `;
 
 const StyledTableData = styled.td<{ $borderTop?: boolean }>`
@@ -43,13 +41,13 @@ const StyledTableDataRow = styled.tr<{ $borderTop?: boolean }>`
 `;
 
 export function Header(props: HeaderProps) {
-  const { personident, navn, saksbehandlernavn, enhet, tittel, årstall } = props;
+  const { saksid, personident, navn, saksbehandlernavn, enhet, årstall } = props;
 
   return (
     <div>
-      <h1>{tittel}</h1>
-      <StyledTableData>
-        <StyledTableHeader>Saksnummer: GENERELL_SAK</StyledTableHeader>
+      <h1>Notat av {dagensDatoFormatert()}</h1>
+      <table>
+        <StyledTableHeader colSpan={3}>Saksnummer: {saksid}</StyledTableHeader>
         <StyledTableDataRow>
           <StyledTableData>
             <b>Hvem saken gjelder</b>
@@ -66,9 +64,9 @@ export function Header(props: HeaderProps) {
         </StyledTableDataRow>
         <StyledTableDataRow>
           <StyledTableData>Saken gjelder:</StyledTableData>
-          <StyledTableData>Vurdering næringsinntekt {årstall}</StyledTableData>
+          <StyledTableData colSpan={2}>Vurdering næringsinntekt {årstall}</StyledTableData>
         </StyledTableDataRow>
-      </StyledTableData>
+      </table>
     </div>
   );
 }

--- a/src/server/næringsinntekt/components/Inntekt.tsx
+++ b/src/server/næringsinntekt/components/Inntekt.tsx
@@ -16,7 +16,7 @@ export function Inntekt(props: InntektProps) {
       </p>
       <p>
         Bruker har hatt næringsinntekt på {næringsinntekt} og personsinntekt på {personinntekt} i{' '}
-        {årstall}. Inntekten er ikke økt. Bruker oppfyller aktivitetskrav som følge av høy nok
+        {årstall}. Inntekten har ikke økt. Bruker oppfyller aktivitetskrav som følge av høy nok
         inntekt, og det trengs ikke hentes inn dokumentasjon rundt aktivitet.
       </p>
     </div>

--- a/src/server/næringsinntekt/components/Inntekt.tsx
+++ b/src/server/næringsinntekt/components/Inntekt.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface InntektProps {
+  forventetInntekt: number;
+  næringsinntekt: number;
+  personinntekt: number;
+  årstall: number;
+}
+
+export function Inntekt(props: InntektProps) {
+  const { forventetInntekt, næringsinntekt, personinntekt, årstall } = props;
+  return (
+    <div>
+      <p>
+        Bruker har mottatt stønad etter redusert FI på {forventetInntekt} i {årstall}
+      </p>
+      <p>
+        Bruker har hatt næringsinntekt på {næringsinntekt} og personsinntekt på {personinntekt} i{' '}
+        {årstall}. Inntekten er ikke økt. Bruker oppfyller aktivitetskrav som følge av høy nok
+        inntekt, og det trengs ikke hentes inn dokumentasjon rundt aktivitet.
+      </p>
+    </div>
+  );
+}

--- a/src/server/næringsinntekt/hentDokumentHtmlNæringsinntekt.tsx
+++ b/src/server/næringsinntekt/hentDokumentHtmlNæringsinntekt.tsx
@@ -3,7 +3,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import css from '../utils/css';
 import { NæringsinntektDokumentData } from '../../typer/dokumentApiNæringsinntekt';
 import { Header } from './components/Header';
-import { dagensDatoFormatert } from '../../../dist/src/utils/dato';
 import { Inntekt } from './components/Inntekt';
 
 enum HtmlLang {
@@ -23,7 +22,7 @@ export const hentDokumentHtmlNæringsinntekt = async (
       <body className={'body'}>
         <div>
           <Header
-            tittel={`Notat av ${dagensDatoFormatert}`}
+            saksid={data.saksid}
             navn={data.navn}
             personident={data.personIdent}
             saksbehandlernavn={data.saksbehandlernavn}

--- a/src/server/næringsinntekt/hentDokumentHtmlNæringsinntekt.tsx
+++ b/src/server/næringsinntekt/hentDokumentHtmlNæringsinntekt.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import css from '../utils/css';
+import { NæringsinntektDokumentData } from '../../typer/dokumentApiNæringsinntekt';
+import { Header } from './components/Header';
+import { dagensDatoFormatert } from '../../../dist/src/utils/dato';
+import { Inntekt } from './components/Inntekt';
+
+enum HtmlLang {
+  NB = 'nb',
+}
+
+export const hentDokumentHtmlNæringsinntekt = async (
+  data: NæringsinntektDokumentData,
+): Promise<string> => {
+  const asyncHtml = () => (
+    <html lang={HtmlLang.NB}>
+      <head>
+        <meta httpEquiv="content-type" content="text/html; charset=utf-8" />
+        <style type="text/css">{css}</style>
+        <title>Næringsinntekt</title>
+      </head>
+      <body className={'body'}>
+        <div>
+          <Header
+            tittel={`Notat av ${dagensDatoFormatert}`}
+            navn={data.navn}
+            personident={data.personIdent}
+            saksbehandlernavn={data.saksbehandlernavn}
+            enhet={data.enhet}
+            årstall={data.årstall}
+          />
+          <Inntekt
+            forventetInntekt={data.forventetInntekt}
+            næringsinntekt={data.næringsinntekt}
+            personinntekt={data.personinntekt}
+            årstall={data.årstall}
+          />
+        </div>
+      </body>
+    </html>
+  );
+
+  const htmldokument = asyncHtml();
+  const dokument = await renderToStaticMarkup(htmldokument);
+
+  return dokument;
+};

--- a/src/server/næringsinntekt/næringsinntektRoutes.ts
+++ b/src/server/næringsinntekt/næringsinntektRoutes.ts
@@ -5,8 +5,10 @@ import { logFerdigstilt } from '../routes';
 import { logError, logSecure } from '@navikt/familie-logging';
 import { hentDokumentHtmlNæringsinntekt } from './hentDokumentHtmlNæringsinntekt';
 import { NæringsinntektDokumentData } from '../../typer/dokumentApiNæringsinntekt';
+import fs from 'fs';
 
 const router = express.Router();
+const { NODE_ENV } = process.env;
 
 router.post('/pdf', async (req: Request, res: Response) => {
   const næringsinntektData: NæringsinntektDokumentData = req.body as NæringsinntektDokumentData;
@@ -27,6 +29,39 @@ router.post('/pdf', async (req: Request, res: Response) => {
     res.status(500).send(`Generering av dokument (pdf) feilet: ${error.message}`);
   }
 });
+
+if (NODE_ENV != 'production' && NODE_ENV != 'preprod') {
+  const lesMockFil = () => {
+    const fileString = fs.readFileSync('./src/server/mock/dummyDataNæringsinntekt.json', {
+      encoding: 'utf-8',
+    });
+    return JSON.parse(fileString);
+  };
+
+  router.post('/dummy-pdf', async (req: Request, res: Response) => {
+    try {
+      const html = await hentDokumentHtmlNæringsinntekt(lesMockFil());
+      const meta = genererMetadata(req);
+      const pdf = await genererPdfBlankett(html, meta);
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename=inntektsnotat.pdf`);
+      res.end(pdf);
+    } catch (feil) {
+      const error = feil as Error;
+      res.status(500).send(`Generering av dokument (pdf) feilet: ${error.message}`);
+    }
+  });
+
+  router.get('/dummy-html', async (_req: Request, res: Response) => {
+    try {
+      const html = await hentDokumentHtmlNæringsinntekt(lesMockFil());
+      res.send(html);
+    } catch (feil) {
+      const error = feil as Error;
+      res.status(500).send(`Generering av dokument (pdf) feilet: ${error.message}`);
+    }
+  });
+}
 
 const loggFeilMedDataTilSecurelog = <T>(data: T, req: Request, feil: Error) => {
   logSecure(

--- a/src/server/næringsinntekt/næringsinntektRoutes.ts
+++ b/src/server/næringsinntekt/næringsinntektRoutes.ts
@@ -1,0 +1,42 @@
+import express, { type Request, type Response } from 'express';
+import { genererMetadata } from '../utils/logging';
+import { genererPdfBlankett } from '../utils/apiBlankett';
+import { logFerdigstilt } from '../routes';
+import { logError, logSecure } from '@navikt/familie-logging';
+import { hentDokumentHtmlNæringsinntekt } from './hentDokumentHtmlNæringsinntekt';
+import { NæringsinntektDokumentData } from '../../typer/dokumentApiNæringsinntekt';
+
+const router = express.Router();
+
+router.post('/pdf', async (req: Request, res: Response) => {
+  const næringsinntektData: NæringsinntektDokumentData = req.body as NæringsinntektDokumentData;
+  const meta = genererMetadata(req);
+
+  try {
+    const html = await hentDokumentHtmlNæringsinntekt(næringsinntektData);
+    const pdf = await genererPdfBlankett(html, meta);
+    logFerdigstilt(req);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename=næringsinntekt-kontroll.pdf`);
+    res.end(pdf);
+  } catch (feil) {
+    const error = feil as Error;
+    logError(`Generering av dokument (pdf) feilet: Sjekk secure-logs`, undefined, meta);
+    loggFeilMedDataTilSecurelog<NæringsinntektDokumentData>(næringsinntektData, req, error);
+
+    res.status(500).send(`Generering av dokument (pdf) feilet: ${error.message}`);
+  }
+});
+
+const loggFeilMedDataTilSecurelog = <T>(data: T, req: Request, feil: Error) => {
+  logSecure(
+    `[${req.method} - ${
+      req.originalUrl
+    }] Genererer notat næringsinntekt-kontroll med request-data feilet med feil=${feil.message}-${
+      feil.stack
+    } med data: ${JSON.stringify(data)}.`,
+    genererMetadata(req),
+  );
+};
+
+export default router;

--- a/src/typer/dokumentApiNæringsinntekt.ts
+++ b/src/typer/dokumentApiNæringsinntekt.ts
@@ -1,4 +1,5 @@
 export interface NæringsinntektDokumentData {
+  saksid: string;
   personIdent: string;
   navn: string;
   saksbehandlernavn: string;

--- a/src/typer/dokumentApiNæringsinntekt.ts
+++ b/src/typer/dokumentApiNæringsinntekt.ts
@@ -1,0 +1,10 @@
+export interface NæringsinntektDokumentData {
+  personIdent: string;
+  navn: string;
+  saksbehandlernavn: string;
+  enhet: string;
+  forventetInntekt: number;
+  næringsinntekt: number;
+  personinntekt: number;
+  årstall: number;
+}


### PR DESCRIPTION
Nytt endepunkt for å lage et notat for ingen endring i inntekt. Dette endepunktet skal tas i bruk i ef-sak hvor inntekten til selvstendig næringsdrivende sjekkes. Testet lokalt.

![Screenshot 2025-01-07 at 12 17 47](https://github.com/user-attachments/assets/784d6561-4cc4-4d46-bb4e-7942b7e63bce)

PR hvor ef-sak kaller dette endepunktet: https://github.com/navikt/familie-ef-sak/pull/2763
