### PR TITLE
Kontantstøtteperioder

### DIFF
--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -98,6 +98,9 @@ export const Dokument = (dokumentProps: DokumentProps) => {
         årsak={dokumentData.behandling.årsak}
         harKontantstøttePerioder={dokumentData.behandling.harKontantstøttePerioder}
         kontantstøttePerioderFraKs={dokumentData.behandling.kontantstøttePerioderFraKs}
+        registeropplysningerOpprettetDato={
+          dokumentData.behandling.registeropplysningerOpprettetDato
+        }
       />
     </div>
   );

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -97,6 +97,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
         søknadsdatoer={dokumentData.søknadsdatoer}
         årsak={dokumentData.behandling.årsak}
         harKontantstøttePerioder={dokumentData.behandling.harKontantstøttePerioder}
+        kontantstøttePerioderFraKs={dokumentData.behandling.kontantstøttePerioderFraKs}
       />
     </div>
   );

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -96,7 +96,6 @@ export const Dokument = (dokumentProps: DokumentProps) => {
         vedtak={dokumentData.vedtak}
         søknadsdatoer={dokumentData.søknadsdatoer}
         årsak={dokumentData.behandling.årsak}
-        harKontantstøttePerioder={dokumentData.behandling.harKontantstøttePerioder}
         kontantstøttePerioderFraKs={dokumentData.behandling.kontantstøttePerioderFraKs}
       />
     </div>

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -96,6 +96,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
         vedtak={dokumentData.vedtak}
         søknadsdatoer={dokumentData.søknadsdatoer}
         årsak={dokumentData.behandling.årsak}
+        harKontantstøttePerioder={dokumentData.behandling.harKontantstøttePerioder}
         kontantstøttePerioderFraKs={dokumentData.behandling.kontantstøttePerioderFraKs}
       />
     </div>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -45,50 +45,57 @@ export const InnvilgetBarnetilsyn: React.FC<{
       <div className={'blankett-page-break'}>
         <h4 className={'blankett'}>Begrunnelse</h4>
         <p style={{ whiteSpace: 'pre-wrap' }}>{begrunnelse}</p>
-        {harKontantstøttePerioder && (
-          <>
-            <h3 className={'blankett'}>Kontantstøtte</h3>
-            <h4>Info fra KS Sak:</h4>
-            <p>
-              {harKontantstøttePerioder
-                ? 'Brukers kontantstøtteperioder (hentet ' +
-                  formaterNullableIsoDato(kontantstøttePerioderFraKs[0].hentetDato) +
-                  ')'
-                : 'Bruker har verken fått eller får kontantstøtte'}
-            </p>
-            <h4>Vurdering:</h4>
-            <p>
-              Er det søkt om, utbetales det eller har det blitt utbetalt kontantstøtte til brukeren
-              eller en brukeren bor med i perioden(e) det er søkt om?{' '}
-              {mapBooleanTilJaNei(harKontantstøttePerioder, true)}
-            </p>
+        <>
+          <h3 className={'blankett'}>Kontantstøtte</h3>
+          <h4>Info fra KS Sak:</h4>
+          <p>
+            {harKontantstøttePerioder
+              ? 'Brukers kontantstøtteperioder (hentet ' +
+                formaterNullableIsoDato(kontantstøttePerioderFraKs[0].hentetDato) +
+                ')'
+              : 'Bruker har verken fått eller får kontantstøtte'}
+          </p>
+          <table className="tabellUtenBorder">
+            <tr>
+              <th>Perioder fra og med</th>
+              <th>Perioder til og med</th>
+              <th>Kilde</th>
+              <th></th>
+            </tr>
             {kontantstøttePerioderFraKs.map((kontantstøtte, indeks) => (
               <tr key={indeks}>
                 <td>{parseOgFormaterÅrMåned(kontantstøtte.fomMåned)}</td>
                 <td>
                   {kontantstøtte.tomMåned ? parseOgFormaterÅrMåned(kontantstøtte.tomMåned) : ''}
                 </td>
-                <td>{'(kilde: ' + kontantstøtte.kilde + ')'}</td>
+                <td>{kontantstøtte.kilde}</td>
               </tr>
             ))}
-            {perioderKontantstøtte.length > 0 && (
-              <table className="tabellUtenBorder">
-                <tr>
-                  <th>Perioder fra og med</th>
-                  <th>Perioder til og med</th>
-                  <th>Kontantstøtte</th>
+          </table>
+          <h4>Vurdering:</h4>
+          <p>
+            Er det søkt om, utbetales det eller har det blitt utbetalt kontantstøtte til brukeren
+            eller en brukeren bor med i perioden(e) det er søkt om?{' '}
+            {mapBooleanTilJaNei(harKontantstøttePerioder, true)}
+          </p>
+          {perioderKontantstøtte.length > 0 && (
+            <table className="tabellUtenBorder">
+              <tr>
+                <th>Perioder fra og med</th>
+                <th>Perioder til og med</th>
+                <th>Kontantstøtte</th>
+              </tr>
+              {perioderKontantstøtte.map((kontantstøtte, indeks) => (
+                <tr key={indeks}>
+                  <td>{parseOgFormaterÅrMåned(kontantstøtte.årMånedFra)}</td>
+                  <td>{parseOgFormaterÅrMåned(kontantstøtte.årMånedTil)}</td>
+                  <td>{kontantstøtte.beløp}</td>
                 </tr>
-                {perioderKontantstøtte.map((kontantstøtte, indeks) => (
-                  <tr key={indeks}>
-                    <td>{parseOgFormaterÅrMåned(kontantstøtte.årMånedFra)}</td>
-                    <td>{parseOgFormaterÅrMåned(kontantstøtte.årMånedTil)}</td>
-                    <td>{kontantstøtte.beløp}</td>
-                  </tr>
-                ))}
-              </table>
-            )}
-          </>
-        )}
+              ))}
+            </table>
+          )}
+        </>
+        )
       </div>
 
       <div className={'blankett-page-break'}>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -4,11 +4,7 @@ import {
   IKontantstøttePerioder,
   ISøknadsdatoer,
 } from '../../../typer/dokumentApiBlankett';
-import {
-  formaterNullableIsoDato,
-  mapBooleanTilJaNei,
-  parseOgFormaterÅrMåned,
-} from '../../utils/util';
+import { formaterIsoDato, mapBooleanTilJaNei, parseOgFormaterÅrMåned } from '../../utils/util';
 import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 
 export const InnvilgetBarnetilsyn: React.FC<{
@@ -37,15 +33,15 @@ export const InnvilgetBarnetilsyn: React.FC<{
       return (
         <p>
           Bruker har verken fått eller får kontantstøtte (oppdatert{' '}
-          {formaterNullableIsoDato(registeropplysningerOpprettetDato)})
+          {formaterIsoDato(registeropplysningerOpprettetDato)})
         </p>
       );
     }
     if (kontantstøttePerioderFraGrunnlagsdata.length > 0) {
       return (
         <p>
-          Brukers kontantstøtteperioder (hentet{' '}
-          {formaterNullableIsoDato(registeropplysningerOpprettetDato)})
+          Brukers kontantstøtteperioder (hentet {formaterIsoDato(registeropplysningerOpprettetDato)}
+          )
         </p>
       );
     }

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -16,7 +16,14 @@ export const InnvilgetBarnetilsyn: React.FC<{
   søknadsdatoer?: ISøknadsdatoer;
   harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({ vedtak, søknadsdatoer, kontantstøttePerioderFraKs, harKontantstøttePerioder }) => {
+  registeropplysningerOpprettetDato: string;
+}> = ({
+  vedtak,
+  søknadsdatoer,
+  kontantstøttePerioderFraKs,
+  harKontantstøttePerioder,
+  registeropplysningerOpprettetDato,
+}) => {
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse } = vedtak;
   const kontantstøtteKilde = (kilde: string): string => {
     return kilde.toLowerCase().includes('kontantstøtte') ? 'KS sak' : kilde.toLowerCase();
@@ -27,13 +34,18 @@ export const InnvilgetBarnetilsyn: React.FC<{
     harKontantstøttePerioder?: boolean,
   ): React.ReactNode => {
     if (!harKontantstøttePerioder && kontantstøttePerioderFraGrunnlagsdata.length === 0) {
-      return <p>Bruker har verken fått eller får kontantstøtte</p>;
+      return (
+        <p>
+          Bruker har verken fått eller får kontantstøtte (oppdatert{' '}
+          {formaterNullableIsoDato(registeropplysningerOpprettetDato)})
+        </p>
+      );
     }
     if (kontantstøttePerioderFraGrunnlagsdata.length > 0) {
       return (
         <p>
           Brukers kontantstøtteperioder (hentet{' '}
-          {formaterNullableIsoDato(kontantstøttePerioderFraGrunnlagsdata[0].hentetDato)})
+          {formaterNullableIsoDato(registeropplysningerOpprettetDato)})
         </p>
       );
     }

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -18,6 +18,9 @@ export const InnvilgetBarnetilsyn: React.FC<{
 }> = ({ vedtak, søknadsdatoer, kontantstøttePerioderFraKs }) => {
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse } = vedtak;
   const harKontantstøttePerioder = kontantstøttePerioderFraKs.length > 0;
+  const kontantstøtteKilde = (kilde: string): string => {
+    return kilde.toLowerCase().includes('kontantstøtte') ? 'KS sak' : kilde.toLowerCase();
+  };
   return (
     <div className={'blankett-page-break'}>
       <h2>Vedtak</h2>
@@ -69,7 +72,7 @@ export const InnvilgetBarnetilsyn: React.FC<{
                   <td>
                     {kontantstøtte.tomMåned ? parseOgFormaterÅrMåned(kontantstøtte.tomMåned) : ''}
                   </td>
-                  <td>{kontantstøtte.kilde}</td>
+                  <td>{kontantstøtteKilde(kontantstøtte.kilde)}</td>
                 </tr>
               ))}
             </table>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -27,6 +27,7 @@ export const InnvilgetBarnetilsyn: React.FC<{
 
   const utledKontantstøtteperioderAlertTekst = (
     kontantstøttePerioderFraGrunnlagsdata: IKontantstøttePerioder[],
+    registeropplysningerOpprettetDato: string,
     harKontantstøttePerioder?: boolean,
   ): React.ReactNode => {
     if (!harKontantstøttePerioder && kontantstøttePerioderFraGrunnlagsdata.length === 0) {
@@ -80,6 +81,7 @@ export const InnvilgetBarnetilsyn: React.FC<{
           <p>
             {utledKontantstøtteperioderAlertTekst(
               kontantstøttePerioderFraKs,
+              registeropplysningerOpprettetDato,
               harKontantstøttePerioder,
             )}
           </p>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import type {
+import {
   IInnvilgeVedtakBarnetilsyn,
+  IKontantstøttePerioder,
   ISøknadsdatoer,
 } from '../../../typer/dokumentApiBlankett';
 import { mapBooleanTilJaNei, parseOgFormaterÅrMåned } from '../../utils/util';
@@ -10,7 +11,8 @@ export const InnvilgetBarnetilsyn: React.FC<{
   vedtak: IInnvilgeVedtakBarnetilsyn;
   søknadsdatoer?: ISøknadsdatoer;
   harKontantstøttePerioder?: boolean;
-}> = ({ vedtak, søknadsdatoer, harKontantstøttePerioder }) => {
+  kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+}> = ({ vedtak, søknadsdatoer, harKontantstøttePerioder, kontantstøttePerioderFraKs }) => {
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse } = vedtak;
   return (
     <div className={'blankett-page-break'}>
@@ -54,6 +56,15 @@ export const InnvilgetBarnetilsyn: React.FC<{
               eller en brukeren bor med i perioden(e) det er søkt om?{' '}
               {mapBooleanTilJaNei(harKontantstøttePerioder, true)}
             </p>
+            {kontantstøttePerioderFraKs.map((kontantstøtte, indeks) => (
+              <tr key={indeks}>
+                <td>{parseOgFormaterÅrMåned(kontantstøtte.fomMåned)}</td>
+                <td>
+                  {kontantstøtte.tomMåned ? parseOgFormaterÅrMåned(kontantstøtte.tomMåned) : ''}
+                </td>
+                <td>{'(kilde: ' + kontantstøtte.kilde + ')'}</td>
+              </tr>
+            ))}
             {perioderKontantstøtte.length > 0 && (
               <table className="tabellUtenBorder">
                 <tr>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -4,7 +4,11 @@ import {
   IKontantstøttePerioder,
   ISøknadsdatoer,
 } from '../../../typer/dokumentApiBlankett';
-import { mapBooleanTilJaNei, parseOgFormaterÅrMåned } from '../../utils/util';
+import {
+  formaterNullableIsoDato,
+  mapBooleanTilJaNei,
+  parseOgFormaterÅrMåned,
+} from '../../utils/util';
 import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 
 export const InnvilgetBarnetilsyn: React.FC<{
@@ -48,7 +52,7 @@ export const InnvilgetBarnetilsyn: React.FC<{
             <p>
               {harKontantstøttePerioder
                 ? 'Brukers kontantstøtteperioder (hentet ' +
-                  kontantstøttePerioderFraKs[0].hentetDato +
+                  formaterNullableIsoDato(kontantstøttePerioderFraKs[0].hentetDato) +
                   ')'
                 : 'Bruker har verken fått eller får kontantstøtte'}
             </p>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -14,12 +14,30 @@ import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 export const InnvilgetBarnetilsyn: React.FC<{
   vedtak: IInnvilgeVedtakBarnetilsyn;
   søknadsdatoer?: ISøknadsdatoer;
+  harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({ vedtak, søknadsdatoer, kontantstøttePerioderFraKs }) => {
+}> = ({ vedtak, søknadsdatoer, kontantstøttePerioderFraKs, harKontantstøttePerioder }) => {
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse } = vedtak;
-  const harKontantstøttePerioder = kontantstøttePerioderFraKs.length > 0;
   const kontantstøtteKilde = (kilde: string): string => {
     return kilde.toLowerCase().includes('kontantstøtte') ? 'KS sak' : kilde.toLowerCase();
+  };
+
+  const utledKontantstøtteperioderAlertTekst = (
+    kontantstøttePerioderFraGrunnlagsdata: IKontantstøttePerioder[],
+    harKontantstøttePerioder?: boolean,
+  ): React.ReactNode => {
+    if (!harKontantstøttePerioder || kontantstøttePerioderFraGrunnlagsdata.length === 0) {
+      return <p>Bruker har verken fått eller får kontantstøtte</p>;
+    }
+    if (kontantstøttePerioderFraGrunnlagsdata.length === 1) {
+      return (
+        <p>
+          Brukers kontantstøtteperioder (hentet{' '}
+          {formaterNullableIsoDato(kontantstøttePerioderFraGrunnlagsdata[0].hentetDato)})
+        </p>
+      );
+    }
+    return <p>Bruker har eller har fått kontantstøtte</p>;
   };
   return (
     <div className={'blankett-page-break'}>
@@ -52,11 +70,10 @@ export const InnvilgetBarnetilsyn: React.FC<{
           <h3 className={'blankett'}>Kontantstøtte</h3>
           <h4>Info fra KS Sak:</h4>
           <p>
-            {harKontantstøttePerioder
-              ? 'Brukers kontantstøtteperioder (hentet ' +
-                formaterNullableIsoDato(kontantstøttePerioderFraKs[0].hentetDato) +
-                ')'
-              : 'Bruker har verken fått eller får kontantstøtte'}
+            {utledKontantstøtteperioderAlertTekst(
+              kontantstøttePerioderFraKs,
+              harKontantstøttePerioder,
+            )}
           </p>
           {harKontantstøttePerioder && (
             <table className="tabellUtenBorder">

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -23,7 +23,7 @@ export const InnvilgetBarnetilsyn: React.FC<{
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse, kontantstøtteBegrunnelse } =
     vedtak;
   const kontantstøtteKilde = (kilde: string): string => {
-    return kilde.toLowerCase().includes('kontantstøtte') ? 'KS sak' : kilde.toLowerCase();
+    return kilde.toLowerCase().includes('ks_sak') ? 'KS sak' : kilde.toLowerCase();
   };
 
   const utledKontantstøtteperioderAlertTekst = (

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -55,23 +55,25 @@ export const InnvilgetBarnetilsyn: React.FC<{
                 ')'
               : 'Bruker har verken fått eller får kontantstøtte'}
           </p>
-          <table className="tabellUtenBorder">
-            <tr>
-              <th>Perioder fra og med</th>
-              <th>Perioder til og med</th>
-              <th>Kilde</th>
-              <th></th>
-            </tr>
-            {kontantstøttePerioderFraKs.map((kontantstøtte, indeks) => (
-              <tr key={indeks}>
-                <td>{parseOgFormaterÅrMåned(kontantstøtte.fomMåned)}</td>
-                <td>
-                  {kontantstøtte.tomMåned ? parseOgFormaterÅrMåned(kontantstøtte.tomMåned) : ''}
-                </td>
-                <td>{kontantstøtte.kilde}</td>
+          {harKontantstøttePerioder && (
+            <table className="tabellUtenBorder">
+              <tr>
+                <th>Perioder fra og med</th>
+                <th>Perioder til og med</th>
+                <th>Kilde</th>
+                <th></th>
               </tr>
-            ))}
-          </table>
+              {kontantstøttePerioderFraKs.map((kontantstøtte, indeks) => (
+                <tr key={indeks}>
+                  <td>{parseOgFormaterÅrMåned(kontantstøtte.fomMåned)}</td>
+                  <td>
+                    {kontantstøtte.tomMåned ? parseOgFormaterÅrMåned(kontantstøtte.tomMåned) : ''}
+                  </td>
+                  <td>{kontantstøtte.kilde}</td>
+                </tr>
+              ))}
+            </table>
+          )}
           <h4>Vurdering:</h4>
           <p>
             Er det søkt om, utbetales det eller har det blitt utbetalt kontantstøtte til brukeren

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -26,10 +26,10 @@ export const InnvilgetBarnetilsyn: React.FC<{
     kontantstøttePerioderFraGrunnlagsdata: IKontantstøttePerioder[],
     harKontantstøttePerioder?: boolean,
   ): React.ReactNode => {
-    if (!harKontantstøttePerioder || kontantstøttePerioderFraGrunnlagsdata.length === 0) {
+    if (!harKontantstøttePerioder && kontantstøttePerioderFraGrunnlagsdata.length === 0) {
       return <p>Bruker har verken fått eller får kontantstøtte</p>;
     }
-    if (kontantstøttePerioderFraGrunnlagsdata.length === 1) {
+    if (kontantstøttePerioderFraGrunnlagsdata.length > 0) {
       return (
         <p>
           Brukers kontantstøtteperioder (hentet{' '}

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -10,10 +10,10 @@ import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 export const InnvilgetBarnetilsyn: React.FC<{
   vedtak: IInnvilgeVedtakBarnetilsyn;
   søknadsdatoer?: ISøknadsdatoer;
-  harKontantstøttePerioder?: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({ vedtak, søknadsdatoer, harKontantstøttePerioder, kontantstøttePerioderFraKs }) => {
+}> = ({ vedtak, søknadsdatoer, kontantstøttePerioderFraKs }) => {
   const { perioder, perioderKontantstøtte, tilleggsstønad, begrunnelse } = vedtak;
+  const harKontantstøttePerioder = kontantstøttePerioderFraKs.length > 0;
   return (
     <div className={'blankett-page-break'}>
       <h2>Vedtak</h2>
@@ -41,13 +41,15 @@ export const InnvilgetBarnetilsyn: React.FC<{
       <div className={'blankett-page-break'}>
         <h4 className={'blankett'}>Begrunnelse</h4>
         <p style={{ whiteSpace: 'pre-wrap' }}>{begrunnelse}</p>
-        {harKontantstøttePerioder !== undefined && (
+        {harKontantstøttePerioder && (
           <>
             <h3 className={'blankett'}>Kontantstøtte</h3>
             <h4>Info fra KS Sak:</h4>
             <p>
               {harKontantstøttePerioder
-                ? 'Bruker har eller har fått kontantstøtte'
+                ? 'Brukers kontantstøtteperioder (hentet ' +
+                  kontantstøttePerioderFraKs[0].hentetDato +
+                  ')'
                 : 'Bruker har verken fått eller får kontantstøtte'}
             </p>
             <h4>Vurdering:</h4>

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -95,7 +95,6 @@ export const InnvilgetBarnetilsyn: React.FC<{
             </table>
           )}
         </>
-        )
       </div>
 
       <div className={'blankett-page-break'}>

--- a/src/server/blankett/components/Vedtak.tsx
+++ b/src/server/blankett/components/Vedtak.tsx
@@ -10,6 +10,7 @@ import type {
   IInnvilgeVedtakOvergangsstønad,
   IInnvilgeVedtakBarnetilsyn,
   IInnvilgeVedtakSkolepenger,
+  IKontantstøttePerioder,
 } from '../../../typer/dokumentApiBlankett';
 import {
   EStønadType,
@@ -23,7 +24,15 @@ export const Vedtak: React.FC<{
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
   harKontantstøttePerioder?: boolean;
-}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, harKontantstøttePerioder }) => {
+  kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+}> = ({
+  stønadstype,
+  vedtak,
+  søknadsdatoer,
+  årsak,
+  harKontantstøttePerioder,
+  kontantstøttePerioderFraKs,
+}) => {
   switch (vedtak.resultatType) {
     case EBehandlingResultat.INNVILGE:
       return (
@@ -33,6 +42,7 @@ export const Vedtak: React.FC<{
           søknadsdatoer={søknadsdatoer}
           årsak={årsak}
           harKontantstøttePerioder={harKontantstøttePerioder}
+          kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );
     case EBehandlingResultat.AVSLÅ:
@@ -48,7 +58,15 @@ const InnvilgetVedtak: React.FC<{
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
   harKontantstøttePerioder?: boolean;
-}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, harKontantstøttePerioder }) => {
+  kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+}> = ({
+  stønadstype,
+  vedtak,
+  søknadsdatoer,
+  årsak,
+  harKontantstøttePerioder,
+  kontantstøttePerioderFraKs,
+}) => {
   if (årsak === EBehandlingÅrsak.G_OMREGNING) {
     return <InnvilgetGOmregning vedtak={vedtak as IInnvilgeVedtakOvergangsstønad} />;
   }
@@ -67,6 +85,7 @@ const InnvilgetVedtak: React.FC<{
           vedtak={vedtak as IInnvilgeVedtakBarnetilsyn}
           søknadsdatoer={søknadsdatoer}
           harKontantstøttePerioder={harKontantstøttePerioder}
+          kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );
     case EStønadType.SKOLEPENGER:

--- a/src/server/blankett/components/Vedtak.tsx
+++ b/src/server/blankett/components/Vedtak.tsx
@@ -25,6 +25,7 @@ export const Vedtak: React.FC<{
   årsak: EBehandlingÅrsak;
   harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+  registeropplysningerOpprettetDato: string;
 }> = ({
   stønadstype,
   vedtak,
@@ -32,6 +33,7 @@ export const Vedtak: React.FC<{
   årsak,
   kontantstøttePerioderFraKs,
   harKontantstøttePerioder,
+  registeropplysningerOpprettetDato,
 }) => {
   switch (vedtak.resultatType) {
     case EBehandlingResultat.INNVILGE:
@@ -43,6 +45,7 @@ export const Vedtak: React.FC<{
           årsak={årsak}
           harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
+          registeropplysningerOpprettetDato={registeropplysningerOpprettetDato}
         />
       );
     case EBehandlingResultat.AVSLÅ:
@@ -59,6 +62,7 @@ const InnvilgetVedtak: React.FC<{
   årsak: EBehandlingÅrsak;
   harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+  registeropplysningerOpprettetDato: string;
 }> = ({
   stønadstype,
   vedtak,
@@ -66,6 +70,7 @@ const InnvilgetVedtak: React.FC<{
   årsak,
   kontantstøttePerioderFraKs,
   harKontantstøttePerioder,
+  registeropplysningerOpprettetDato,
 }) => {
   if (årsak === EBehandlingÅrsak.G_OMREGNING) {
     return <InnvilgetGOmregning vedtak={vedtak as IInnvilgeVedtakOvergangsstønad} />;
@@ -86,6 +91,7 @@ const InnvilgetVedtak: React.FC<{
           søknadsdatoer={søknadsdatoer}
           harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
+          registeropplysningerOpprettetDato={registeropplysningerOpprettetDato}
         />
       );
     case EStønadType.SKOLEPENGER:

--- a/src/server/blankett/components/Vedtak.tsx
+++ b/src/server/blankett/components/Vedtak.tsx
@@ -23,16 +23,8 @@ export const Vedtak: React.FC<{
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
-  harKontantstøttePerioder?: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({
-  stønadstype,
-  vedtak,
-  søknadsdatoer,
-  årsak,
-  harKontantstøttePerioder,
-  kontantstøttePerioderFraKs,
-}) => {
+}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, kontantstøttePerioderFraKs }) => {
   switch (vedtak.resultatType) {
     case EBehandlingResultat.INNVILGE:
       return (
@@ -41,7 +33,6 @@ export const Vedtak: React.FC<{
           vedtak={vedtak}
           søknadsdatoer={søknadsdatoer}
           årsak={årsak}
-          harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );
@@ -57,16 +48,8 @@ const InnvilgetVedtak: React.FC<{
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
-  harKontantstøttePerioder?: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({
-  stønadstype,
-  vedtak,
-  søknadsdatoer,
-  årsak,
-  harKontantstøttePerioder,
-  kontantstøttePerioderFraKs,
-}) => {
+}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, kontantstøttePerioderFraKs }) => {
   if (årsak === EBehandlingÅrsak.G_OMREGNING) {
     return <InnvilgetGOmregning vedtak={vedtak as IInnvilgeVedtakOvergangsstønad} />;
   }
@@ -84,7 +67,6 @@ const InnvilgetVedtak: React.FC<{
         <InnvilgetBarnetilsyn
           vedtak={vedtak as IInnvilgeVedtakBarnetilsyn}
           søknadsdatoer={søknadsdatoer}
-          harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );

--- a/src/server/blankett/components/Vedtak.tsx
+++ b/src/server/blankett/components/Vedtak.tsx
@@ -23,8 +23,16 @@ export const Vedtak: React.FC<{
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
+  harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, kontantstøttePerioderFraKs }) => {
+}> = ({
+  stønadstype,
+  vedtak,
+  søknadsdatoer,
+  årsak,
+  kontantstøttePerioderFraKs,
+  harKontantstøttePerioder,
+}) => {
   switch (vedtak.resultatType) {
     case EBehandlingResultat.INNVILGE:
       return (
@@ -33,6 +41,7 @@ export const Vedtak: React.FC<{
           vedtak={vedtak}
           søknadsdatoer={søknadsdatoer}
           årsak={årsak}
+          harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );
@@ -48,8 +57,16 @@ const InnvilgetVedtak: React.FC<{
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
   årsak: EBehandlingÅrsak;
+  harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
-}> = ({ stønadstype, vedtak, søknadsdatoer, årsak, kontantstøttePerioderFraKs }) => {
+}> = ({
+  stønadstype,
+  vedtak,
+  søknadsdatoer,
+  årsak,
+  kontantstøttePerioderFraKs,
+  harKontantstøttePerioder,
+}) => {
   if (årsak === EBehandlingÅrsak.G_OMREGNING) {
     return <InnvilgetGOmregning vedtak={vedtak as IInnvilgeVedtakOvergangsstønad} />;
   }
@@ -67,6 +84,7 @@ const InnvilgetVedtak: React.FC<{
         <InnvilgetBarnetilsyn
           vedtak={vedtak as IInnvilgeVedtakBarnetilsyn}
           søknadsdatoer={søknadsdatoer}
+          harKontantstøttePerioder={harKontantstøttePerioder}
           kontantstøttePerioderFraKs={kontantstøttePerioderFraKs}
         />
       );

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -11,6 +11,7 @@ export interface IBehandling {
   stønadstype: EStønadType;
   årsakRevurdering?: IÅrsakRevurdering;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
+  harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
 }
 

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -11,7 +11,6 @@ export interface IBehandling {
   stønadstype: EStønadType;
   årsakRevurdering?: IÅrsakRevurdering;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
-  harKontantstøttePerioder?: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
 }
 
@@ -107,6 +106,7 @@ export type IKontantstøttePerioder = {
   fomMåned: string;
   tomMåned?: string;
   kilde: string;
+  hentetDato: string;
 };
 
 export const studietypeTilTekst: Record<ESkolepengerStudietype, string> = {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -12,6 +12,7 @@ export interface IBehandling {
   årsakRevurdering?: IÅrsakRevurdering;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
   harKontantstøttePerioder?: boolean;
+  kontantstøttePerioderFraKs: IKontantstøttePerioder[];
 }
 
 export interface ITidligereVedtaksperioder {
@@ -100,6 +101,12 @@ export type IDelårsperiodeSkoleårDto = {
   årMånedFra: string;
   årMånedTil: string;
   studiebelastning: number;
+};
+
+export type IKontantstøttePerioder = {
+  fomMåned: string;
+  tomMåned?: string;
+  kilde: string;
 };
 
 export const studietypeTilTekst: Record<ESkolepengerStudietype, string> = {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -13,6 +13,7 @@ export interface IBehandling {
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
   harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
+  registeropplysningerOpprettetDato: string;
 }
 
 export interface ITidligereVedtaksperioder {
@@ -107,7 +108,6 @@ export type IKontantstøttePerioder = {
   fomMåned: string;
   tomMåned?: string;
   kilde: string;
-  hentetDato: string;
 };
 
 export const studietypeTilTekst: Record<ESkolepengerStudietype, string> = {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23283

Hvorfor ? 

Trenger å vise kontantstøtteperioder fra KS i blankett. Trenger også en referansedato (ref "hentet" i screenshot). 

ef-sak: https://github.com/navikt/familie-ef-sak/pull/2756
ef-sak-frontend: https://github.com/navikt/familie-ef-sak-frontend/pull/2988

![image](https://github.com/user-attachments/assets/b699b653-496c-43a7-b928-ceb73e78b981)

Når kontantstøtteperioder ikke finnes: 
![image](https://github.com/user-attachments/assets/c6d0ac0d-ba84-42b3-96f7-9435284ed8e0)

