### PR TITLE
Bestluttersignatur på venstre side i brev 

### DIFF
--- a/src/server/hentAvansertDokumentHtml.tsx
+++ b/src/server/hentAvansertDokumentHtml.tsx
@@ -76,12 +76,12 @@ export const hentAvansertDokumentHtml = async (
             <div>
               <div>{enhet || 'Nav Arbeid og ytelser'}</div>
               <p style={{ float: 'left' }}>
-                <span style={{ marginRight: '20px' }}>{saksbehandlersignatur}</span>
                 {!skjulBeslutterSignatur && (
                   <>
-                    <span style={{ marginLeft: '20px' }}>{besluttersignatur}</span>
+                    <span style={{ marginRight: '20px' }}>{besluttersignatur}</span>
                   </>
                 )}
+                <span style={{ marginLeft: '20px' }}>{saksbehandlersignatur}</span>
               </p>
             </div>
           </div>

--- a/src/server/lagManueltBrevHtml.tsx
+++ b/src/server/lagManueltBrevHtml.tsx
@@ -36,10 +36,10 @@ export const lagManueltBrevHtml = (brevMedSignatur: IFritekstbrevMedSignatur) =>
             <div>{brevMedSignatur.enhet || 'Nav Arbeid og ytelser'}</div>
             <br />
             <div style={{ marginRight: '20px' }}>
-              {brevMedSignatur.saksbehandlersignatur}{' '}
               {brevMedSignatur.besluttersignatur && (
                 <span style={{ marginLeft: '20px' }}>{brevMedSignatur.besluttersignatur}</span>
-              )}
+              )}{' '}
+              {brevMedSignatur.saksbehandlersignatur}
             </div>
           </p>
         </div>


### PR DESCRIPTION
### Hvorfor ? 

Besluttersignaturer skal være på venstresiden i brev ifølge Nav sin brevstandard. 

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24032

![image](https://github.com/user-attachments/assets/55c9058f-60e5-48e2-96dd-1224869273d2)
