### PR TITLE
For å støtte html-inputfelt med quill må vi konvertere flettefelt-tek…

### DIFF
--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -47,18 +47,23 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
   }
 };
 
+/**
+ * Skal ikke ha en ekstra linjeskift på slutten av hvert avsnitt
+ * Dersom siste element er ikke er "tomt" (som betyr \n) så skippes <br />-taggen
+ */
 const konverterFlettefeltTekstMedNewLineTilBrTag = (
   flettefeltElement: string,
   høyrestill: boolean,
 ) => {
-  return flettefeltElement?.split('\n').map((avsnitt, index) => {
+  return flettefeltElement?.split('\n').map((avsnitt, index, total) => {
+    const erSisteElement = total.length - 1 === index;
+    const erLinjeskiftElement = avsnitt.length === 0;
+    const skalHaBreaklineTag = erLinjeskiftElement || !erSisteElement;
     return (
-      <>
-        <span key={index} className={høyrestill ? 'høyrestill' : ''}>
-          {avsnitt}
-        </span>
-        <br key={index} />
-      </>
+      <React.Fragment key={index}>
+        <span className={høyrestill ? 'høyrestill' : ''}>{avsnitt}</span>
+        {skalHaBreaklineTag && <br />}
+      </React.Fragment>
     );
   });
 };

--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -49,7 +49,7 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
 
 /**
  * Skal ikke ha en ekstra linjeskift på slutten av hvert avsnitt
- * Dersom siste element er ikke er "tomt" (som betyr \n) så skippes <br />-taggen
+ * Dersom siste elementet ikke er "tomt" (som betyr \n) så skippes <br />-taggen på slutten
  */
 const konverterFlettefeltTekstMedNewLineTilBrTag = (
   flettefeltElement: string,

--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -43,7 +43,20 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
       </ul>
     );
   } else {
-    return <span className={høyrestill ? 'høyrestill' : ''}>{flettefelt[0]}</span>;
+    return flettefelt[0]?.split('\n').map((avsnitt, index, total) => {
+      const erLinjeskiftMellomToAvsnitt = total.length - 1 !== index;
+      const erAvsnittMedTekst = avsnitt.length > 0;
+      return erAvsnittMedTekst ? (
+        <>
+          <span key={index} className={høyrestill ? 'høyrestill' : ''}>
+            {avsnitt}
+          </span>
+          {erLinjeskiftMellomToAvsnitt && <br />}
+        </>
+      ) : (
+        <br key={index} />
+      );
+    });
   }
 };
 

--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -43,17 +43,24 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
       </ul>
     );
   } else {
-    return flettefelt[0]?.split('\n').map((avsnitt, index) => {
-      return (
-        <>
-          <span key={index} className={høyrestill ? 'høyrestill' : ''}>
-            {avsnitt}
-          </span>
-          <br key={index} />
-        </>
-      );
-    });
+    return konverterFlettefeltTekstMedNewLineTilBrTag(flettefelt[0], høyrestill);
   }
+};
+
+const konverterFlettefeltTekstMedNewLineTilBrTag = (
+  flettefeltElement: string,
+  høyrestill: boolean,
+) => {
+  return flettefeltElement?.split('\n').map((avsnitt, index) => {
+    return (
+      <>
+        <span key={index} className={høyrestill ? 'høyrestill' : ''}>
+          {avsnitt}
+        </span>
+        <br key={index} />
+      </>
+    );
+  });
 };
 
 const hentFlettefeltNavn = (sanityProps: any) => {

--- a/src/server/components/serializers/FlettefeltSerializer.tsx
+++ b/src/server/components/serializers/FlettefeltSerializer.tsx
@@ -43,18 +43,14 @@ export const FlettefeltSerializer = (props: IFlettefeltSerializerProps) => {
       </ul>
     );
   } else {
-    return flettefelt[0]?.split('\n').map((avsnitt, index, total) => {
-      const erLinjeskiftMellomToAvsnitt = total.length - 1 !== index;
-      const erAvsnittMedTekst = avsnitt.length > 0;
-      return erAvsnittMedTekst ? (
+    return flettefelt[0]?.split('\n').map((avsnitt, index) => {
+      return (
         <>
           <span key={index} className={høyrestill ? 'høyrestill' : ''}>
             {avsnitt}
           </span>
-          {erLinjeskiftMellomToAvsnitt && <br />}
+          <br key={index} />
         </>
-      ) : (
-        <br key={index} />
       );
     });
   }


### PR DESCRIPTION
…ster med newline \n til å bli html-linjeskift <br />. Har testet lokalt i EF og ser ut til å være bakoverkompatibelt i vanlig brevbygger