### PR TITLE
skal vise en oppsummering av kalkulert samvær for barn på aleneomsorg…

### DIFF
--- a/src/server/blankett/components/AleneomsorgGrunnlag.tsx
+++ b/src/server/blankett/components/AleneomsorgGrunnlag.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { AnnenForelder } from './AnnenForelder';
-import type { IBarnMedSamvær, IPersonalia } from '../../../typer/dokumentApiBlankett';
+import {
+  IBarnMedSamvær,
+  IPersonalia,
+  samværsandelTilVerdi,
+  Samværsavtale,
+  Samværsdag,
+  Samværsuke,
+} from '../../../typer/dokumentApiBlankett';
 import { formaterNullableIsoDato } from '../../utils/util';
 
 interface Props {
   barnMedSamvær: IBarnMedSamvær[];
   personalia: IPersonalia;
   barnId?: string;
+  samværsavtaler?: Samværsavtale[]; //TODO: Fjern nullable etter at familie-ef-sak har blitt prodsatt
 }
 
 const navnPåBarnet = (barnMedSamvær: IBarnMedSamvær) => {
@@ -30,7 +38,34 @@ const utledBostedTekst = (harDeltBosted: boolean, harSammeAdresse: boolean | und
   return 'Ikke registrert på brukers adresse';
 };
 
-export const AleneomsorgGrunnlag: React.FC<Props> = ({ barnMedSamvær, barnId, personalia }) => {
+export const utledVisningstekstForSamværsavtale = (samværsuker: Samværsuke[]) => {
+  const summertSamvær = samværsuker
+    .flatMap(samværsuke =>
+      Object.values(samværsuke).flatMap((samværsdag: Samværsdag) => samværsdag.andeler),
+    )
+    .map(andel => samværsandelTilVerdi[andel])
+    .reduce((acc, andel) => acc + andel, 0);
+
+  const maksimalSamværsandel = samværsuker.length * 7 * 8;
+
+  const antallHeleDagerMedSamvær = Math.floor(summertSamvær / 8);
+
+  const rest = summertSamvær % 8;
+  const restSuffix = rest === 0 ? '' : '/8';
+
+  const prosentandel = summertSamvær / maksimalSamværsandel;
+
+  const visningstekstAntallDager = `${antallHeleDagerMedSamvær} dager og ${rest}${restSuffix} deler`;
+  const visningstekstProsentandel = `${Math.round(prosentandel * 1000) / 10}%`;
+  return `Samværsandel: ${visningstekstAntallDager} = ${visningstekstProsentandel}`;
+};
+
+export const AleneomsorgGrunnlag: React.FC<Props> = ({
+  barnMedSamvær,
+  barnId,
+  personalia,
+  samværsavtaler,
+}) => {
   return (
     <>
       <h3 className={'blankett'}>Registerdata</h3>
@@ -41,6 +76,10 @@ export const AleneomsorgGrunnlag: React.FC<Props> = ({ barnMedSamvær, barnId, p
             barn.registergrunnlag;
 
           const skalViseAdresser = !harDeltBostedVedGrunnlagsdataopprettelse && !harSammeAdresse;
+
+          const samværsavtale = samværsavtaler?.find(
+            samværsavtale => samværsavtale.behandlingBarnId === barnId,
+          );
 
           return (
             <div key={index}>
@@ -66,6 +105,7 @@ export const AleneomsorgGrunnlag: React.FC<Props> = ({ barnMedSamvær, barnId, p
                 {barn.registergrunnlag?.forelder?.visningsadresse ||
                   'Mangler gjeldende bostedsadresse'}
               </div>
+              {samværsavtale && <div>{utledVisningstekstForSamværsavtale(samværsavtale.uker)}</div>}
             </div>
           );
         })}

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -61,6 +61,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
   const grunnlag = dokumentData.vilkår.grunnlag;
   const erManuellGOmregning = dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
   const stønadstype = dokumentData.behandling.stønadstype;
+  const samværsavtaler = dokumentData.samværsavtaler;
 
   return (
     <div>
@@ -84,6 +85,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
                   barnId={vurdering.barnId}
                   tidligereVedtaksperioder={tidligereVedtaksperioder}
                   stønadstype={stønadstype}
+                  samværsavtaler={samværsavtaler}
                 />
                 <Vilkårsvurdering vurdering={vurdering} />
               </div>

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -13,6 +13,7 @@ import type {
   IVilkårGrunnlag,
   ITidligereVedtaksperioder,
   EStønadType,
+  Samværsavtale,
 } from '../../../typer/dokumentApiBlankett';
 import { EStønadType as StønadType } from '../../../typer/dokumentApiBlankett';
 import { VilkårGruppe, Vilkår } from '../../../typer/dokumentApiBlankett';
@@ -24,6 +25,7 @@ export interface RegistergrunnlagForVilkårProps {
   barnId?: string;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
   stønadstype: EStønadType;
+  samværsavtaler?: Samværsavtale[];
 }
 
 export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProps> = ({
@@ -32,6 +34,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
   barnId,
   tidligereVedtaksperioder,
   stønadstype,
+  samværsavtaler,
 }) => {
   switch (vilkårgruppe) {
     case VilkårGruppe.MEDLEMSKAP:
@@ -50,6 +53,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
           barnMedSamvær={grunnlag.barnMedSamvær}
           barnId={barnId}
           personalia={grunnlag.personalia}
+          samværsavtaler={samværsavtaler}
         />
       );
     case VilkårGruppe.ALDER_PÅ_BARN:

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -4,6 +4,7 @@ export interface IDokumentData {
   personopplysninger: IPersonopplysninger;
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
+  samværsavtaler?: Samværsavtale[]; // TODO: Fjern nullable her og alle etterfølgende steder etter at familie-ef-sak er prodsatt
 }
 
 export interface IBehandling {
@@ -915,4 +916,38 @@ export const avslagÅrsakTilTekst: Record<EAvslagÅrsak, string> = {
   STØNADSTID_OPPBRUKT: 'Stønadstiden er brukt opp',
   MINDRE_INNTEKTSENDRINGER: 'Ikke 10 % endring inntekt',
   KORTVARIG_AVBRUDD_JOBB: 'Kortvarig avbrudd jobb',
+};
+
+export interface Samværsavtale {
+  behandlingId: string;
+  behandlingBarnId: string;
+  uker: Samværsuke[];
+}
+
+export interface Samværsuke {
+  mandag: Samværsdag;
+  tirsdag: Samværsdag;
+  onsdag: Samværsdag;
+  torsdag: Samværsdag;
+  fredag: Samværsdag;
+  lørdag: Samværsdag;
+  søndag: Samværsdag;
+}
+
+export interface Samværsdag {
+  andeler: Samværsandel[];
+}
+
+export enum Samværsandel {
+  KVELD_NATT = 'KVELD_NATT',
+  MORGEN = 'MORGEN',
+  BARNEHAGE_SKOLE = 'BARNEHAGE_SKOLE',
+  ETTERMIDDAG = 'ETTERMIDDAG',
+}
+
+export const samværsandelTilVerdi: Record<Samværsandel, number> = {
+  KVELD_NATT: 4,
+  MORGEN: 1,
+  BARNEHAGE_SKOLE: 2,
+  ETTERMIDDAG: 1,
 };


### PR DESCRIPTION
…svilkår

En del av ny feature for kalkulering av samvær. Vi ønsker å automatisk lagre ned en oppsummering av samværet som saksbehandler potensielt har kalkulert for et barn under aleneomsorgsvilkåret. Oppsummeringen skal foreløpig være på formatet:
Samværsandel: x dager og x andeler = x% (eksempel under fra ef-sak):
![Skjermbilde 2025-02-13 kl  12 38 00](https://github.com/user-attachments/assets/016b3d57-fa87-4b5c-946d-84d9f4da99ee)

Tilhørende backend-PR:
* https://github.com/navikt/familie-ef-sak/pull/2769
