### PR TITLE
NAV-24774: Legger til begrunnelse for oppfylt klagefrist-unntak i blankett

### DIFF
--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -27,12 +27,6 @@ const påklagetVedtak = (påklagetVedtak?: IPåklagetVedtak) => {
   }
 };
 
-const alleFormkravOppfylt = (formkrav: IFormkravVilkår): boolean =>
-  formkrav.klagePart == EFormVilkår.OPPFYLT &&
-  formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
-  formkrav.klagefristOverholdt == EFormVilkår.OPPFYLT &&
-  formkrav.klageSignert == EFormVilkår.OPPFYLT;
-
 const alleFormkravUtenomKlagefristOppfylt = (formkrav: IFormkravVilkår): boolean =>
   formkrav.klagePart == EFormVilkår.OPPFYLT &&
   formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
@@ -94,7 +88,7 @@ export const KlageFormkrav: React.FC<{ formkrav: IFormkravVilkår }> = ({ formkr
             <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.saksbehandlerBegrunnelse}</span>
           </>
         )}
-        {!alleFormkravOppfylt(formkrav) && !klagefristUnntakOppfylt && formkrav.brevtekst && (
+        {!alleFormkravUtenomKlagefristOppfylt(formkrav) && formkrav.brevtekst && (
           <>
             <h4 className={'blankett'}>Fritekst til brev</h4>
             <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</span>

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -42,8 +42,8 @@ const klagefristUnntakOppfylt = (
   klagefristOverholdtUnntak: FormkravFristUnntak | undefined,
 ): boolean =>
   klagefristOverholdtUnntak != undefined &&
-  !![FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES].find(
-    formkravFristUnntak => formkravFristUnntak == klagefristOverholdtUnntak,
+  [FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES].includes(
+    klagefristOverholdtUnntak,
   );
 
 export const KlageBehandling: React.FC<{ behandling: IKlageBehandling }> = ({ behandling }) => {

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -42,8 +42,9 @@ const klagefristUnntakOppfylt = (
   klagefristOverholdtUnntak: FormkravFristUnntak | undefined,
 ): boolean =>
   klagefristOverholdtUnntak != undefined &&
-  klagefristOverholdtUnntak in
-    [FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES];
+  !![FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES].find(
+    formkravFristUnntak => formkravFristUnntak == klagefristOverholdtUnntak,
+  );
 
 export const KlageBehandling: React.FC<{ behandling: IKlageBehandling }> = ({ behandling }) => {
   return (

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -27,6 +27,12 @@ const påklagetVedtak = (påklagetVedtak?: IPåklagetVedtak) => {
   }
 };
 
+const alleFormkravOppfylt = (formkrav: IFormkravVilkår) =>
+  formkrav.klagePart == EFormVilkår.OPPFYLT &&
+  formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
+  formkrav.klagefristOverholdt == EFormVilkår.OPPFYLT &&
+  formkrav.klageSignert == EFormVilkår.OPPFYLT;
+
 const alleFormkravUtenomKlagefristOppfylt = (formkrav: IFormkravVilkår): boolean =>
   formkrav.klagePart == EFormVilkår.OPPFYLT &&
   formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
@@ -88,12 +94,14 @@ export const KlageFormkrav: React.FC<{ formkrav: IFormkravVilkår }> = ({ formkr
             <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.saksbehandlerBegrunnelse}</span>
           </>
         )}
-        {!alleFormkravUtenomKlagefristOppfylt(formkrav) && formkrav.brevtekst && (
-          <>
-            <h4 className={'blankett'}>Fritekst til brev</h4>
-            <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</span>
-          </>
-        )}
+        {!alleFormkravOppfylt(formkrav) &&
+          !klagefristUnntakOppfylt(formkrav.klagefristOverholdtUnntak) &&
+          formkrav.brevtekst && (
+            <>
+              <h4 className={'blankett'}>Fritekst til brev</h4>
+              <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</span>
+            </>
+          )}
       </>
     </div>
   );
@@ -108,7 +116,8 @@ export const Klagevurdering: React.FC<{
   }
 
   const skalInkludereKlagefristUnntakBegrunnelse =
-    alleFormkravUtenomKlagefristOppfylt(formkrav) && klagefristUnntakOppfylt;
+    alleFormkravUtenomKlagefristOppfylt(formkrav) &&
+    klagefristUnntakOppfylt(formkrav.klagefristOverholdtUnntak);
 
   return (
     <div className={'blankett-page-break'}>

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -152,10 +152,10 @@ export const Klagevurdering: React.FC<{
         vurdering.vurderingAvKlagen && (
           <>
             <h4 className={'blankett'}>Innstilling til Nav Klageinstans</h4>
-            <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.dokumentasjonOgUtredning}</p>
             {skalInkludereKlagefristUnntakBegrunnelse && (
               <p style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</p>
             )}
+            <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.dokumentasjonOgUtredning}</p>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.spørsmåletISaken}</p>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.aktuelleRettskilder}</p>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.klagersAnførsler}</p>

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 
 import { formaterIsoDato, formaterIsoDatoTid } from '../../utils/util';
-import type {
-  IFormkravVilkår,
-  IKlageBehandling,
-  IPåklagetVedtak,
-} from '../../../typer/klageDokumentApi';
 import {
   behandlingResultatTilTekst,
   EFormVilkår,
+  FormkravFristUnntak,
   formkravFristUnntakTilTekst,
   formVilkårTilTekst,
   hjemmelTilVisningstekst,
+  IFormkravVilkår,
+  IKlageBehandling,
+  IPåklagetVedtak,
   IVurdering,
   klagebehandlingsårakTilTekst,
   vedtakTilTekst,
@@ -27,6 +26,24 @@ const påklagetVedtak = (påklagetVedtak?: IPåklagetVedtak) => {
     )}`;
   }
 };
+
+const alleFormkravOppfylt = (formkrav: IFormkravVilkår): boolean =>
+  formkrav.klagePart == EFormVilkår.OPPFYLT &&
+  formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
+  formkrav.klagefristOverholdt == EFormVilkår.OPPFYLT &&
+  formkrav.klageSignert == EFormVilkår.OPPFYLT;
+
+const alleFormkravUtenomKlagefristOppfylt = (formkrav: IFormkravVilkår): boolean =>
+  formkrav.klagePart == EFormVilkår.OPPFYLT &&
+  formkrav.klageKonkret == EFormVilkår.OPPFYLT &&
+  formkrav.klageSignert == EFormVilkår.OPPFYLT;
+
+const klagefristUnntakOppfylt = (
+  klagefristOverholdtUnntak: FormkravFristUnntak | undefined,
+): boolean =>
+  klagefristOverholdtUnntak != undefined &&
+  klagefristOverholdtUnntak in
+    [FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES];
 
 export const KlageBehandling: React.FC<{ behandling: IKlageBehandling }> = ({ behandling }) => {
   return (
@@ -77,7 +94,7 @@ export const KlageFormkrav: React.FC<{ formkrav: IFormkravVilkår }> = ({ formkr
             <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.saksbehandlerBegrunnelse}</span>
           </>
         )}
-        {formkrav.brevtekst && (
+        {!alleFormkravOppfylt(formkrav) && !klagefristUnntakOppfylt && formkrav.brevtekst && (
           <>
             <h4 className={'blankett'}>Fritekst til brev</h4>
             <span style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</span>
@@ -88,10 +105,16 @@ export const KlageFormkrav: React.FC<{ formkrav: IFormkravVilkår }> = ({ formkr
   );
 };
 
-export const Klagevurdering: React.FC<{ vurdering?: IVurdering }> = ({ vurdering }) => {
-  if (!vurdering) {
+export const Klagevurdering: React.FC<{
+  vurdering?: IVurdering;
+  formkrav?: IFormkravVilkår;
+}> = ({ vurdering, formkrav }) => {
+  if (!vurdering || !formkrav) {
     return null;
   }
+
+  const skalInkludereKlagefristUnntakBegrunnelse =
+    alleFormkravUtenomKlagefristOppfylt(formkrav) && klagefristUnntakOppfylt;
 
   return (
     <div className={'blankett-page-break'}>
@@ -130,6 +153,9 @@ export const Klagevurdering: React.FC<{ vurdering?: IVurdering }> = ({ vurdering
           <>
             <h4 className={'blankett'}>Innstilling til Nav Klageinstans</h4>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.dokumentasjonOgUtredning}</p>
+            {skalInkludereKlagefristUnntakBegrunnelse && (
+              <p style={{ whiteSpace: 'pre-wrap' }}>{formkrav.brevtekst}</p>
+            )}
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.spørsmåletISaken}</p>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.aktuelleRettskilder}</p>
             <p style={{ whiteSpace: 'pre-wrap' }}>{vurdering.klagersAnførsler}</p>

--- a/src/server/blankett/genererKlageDokumentHtml.tsx
+++ b/src/server/blankett/genererKlageDokumentHtml.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import type { IKlageDokumentData } from '../../typer/klageDokumentApi';
-import { stønadstypeTilTekst } from '../../typer/klageDokumentApi';
+import { IKlageDokumentData, stønadstypeTilTekst } from '../../typer/klageDokumentApi';
 import { KlageBehandling, KlageFormkrav, Klagevurdering } from './components/KlageBehandling';
 import { Header } from './components/Header';
 import css from '../utils/css';
 import { datoFormat } from '../utils/util';
+
 enum HtmlLang {
   NB = 'nb',
 }
@@ -29,7 +29,7 @@ export const hentDokumentHtml = async (data: IKlageDokumentData): Promise<string
           />
           <KlageBehandling behandling={data.behandling} />
           <KlageFormkrav formkrav={data.formkrav} />
-          <Klagevurdering vurdering={data.vurdering} />
+          <Klagevurdering vurdering={data.vurdering} formkrav={data.formkrav} />
         </div>
       </body>
     </html>


### PR DESCRIPTION
Sørger for at brevtekst vises på rett sted i blankett avhengig av om den representerer en begrunnelse for ikke-oppfylte vilkår eller for oppfylt klagefrist-unntak.

Screenshots:

Når alle formal-vilkår er oppfylt unntatt klagefrist og klager oppfyller et av unntakene til klagefrist vises fritekst først under "Instillinger til Nav Klageinstans"
![image](https://github.com/user-attachments/assets/ef618921-6019-4f77-847f-499b81062fad)

Dersom et av de andre formal-vilkårene ikke er oppfylt vises fritekst under "Fritekst til brev" i "Formkrav":
![image](https://github.com/user-attachments/assets/019b3aab-1c98-4a9b-a26c-9768a0ae00b1)
