### PR TITLE
Dokumentere samværsberegning

### DIFF
--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -10,7 +10,7 @@ import {
   vilkårTypeTilTekst,
 } from '../../../typer/dokumentApiBlankett';
 import { RegistergrunnlagForVilkår } from './RegistergrunnlagForVilkår';
-import { SamværsavtaleVisning } from './SamværsavtaleVisning';
+import { Samværsavtale } from './Samværsavtale';
 
 interface DokumentProps {
   dokumentData: IDokumentData;
@@ -93,8 +93,8 @@ export const Dokument = (dokumentProps: DokumentProps) => {
                   tidligereVedtaksperioder={tidligereVedtaksperioder}
                   stønadstype={stønadstype}
                 />
-                <Vilkårsvurdering vurdering={vurdering} samværsavtaler={samværsavtaler} />
-                {samværsavtale && <SamværsavtaleVisning avtale={samværsavtale} />}
+                <Vilkårsvurdering vurdering={vurdering} />
+                {samværsavtale && <Samværsavtale samværsavtale={samværsavtale} />}
               </div>
             );
           });

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -63,7 +63,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
   const grunnlag = dokumentData.vilkår.grunnlag;
   const erManuellGOmregning = dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
   const stønadstype = dokumentData.behandling.stønadstype;
-  const samværsavtaler = dokumentData.samværsavtaler;
+  const beregnetSamvær = dokumentData.beregnetSamvær;
 
   return (
     <div>
@@ -78,9 +78,9 @@ export const Dokument = (dokumentProps: DokumentProps) => {
           }
 
           return vurderinger.map(vurdering => {
-            const samværsavtale =
+            const beregnetSamværForVilkårsvurdering =
               vurdering.vilkårType === Vilkår.ALENEOMSORG
-                ? samværsavtaler.find(avtale => avtale.behandlingBarnId === vurdering.barnId)
+                ? beregnetSamvær.find(beregning => beregning.behandlingBarnId === vurdering.barnId)
                 : undefined;
 
             return (
@@ -94,7 +94,9 @@ export const Dokument = (dokumentProps: DokumentProps) => {
                   stønadstype={stønadstype}
                 />
                 <Vilkårsvurdering vurdering={vurdering} />
-                {samværsavtale && <Samværsavtale samværsavtale={samværsavtale} />}
+                {beregnetSamværForVilkårsvurdering && (
+                  <Samværsavtale beregnetSamvær={beregnetSamværForVilkårsvurdering} />
+                )}
               </div>
             );
           });

--- a/src/server/blankett/components/Samværsavtale.tsx
+++ b/src/server/blankett/components/Samværsavtale.tsx
@@ -1,43 +1,19 @@
 import React from 'react';
-import {
-  samværsandelTilVerdi,
-  Samværsavtale as Avtale,
-  Samværsdag,
-  Samværsuke,
-} from '../../../typer/dokumentApiBlankett';
+import { BeregnetSamvær } from '../../../typer/dokumentApiBlankett';
+import { utledDeloverskrift } from '../../lagManueltBrevHtml';
 
 interface Props {
-  samværsavtale: Avtale;
+  beregnetSamvær: BeregnetSamvær;
 }
 
-const utledOppsummering = (samværsuker: Samværsuke[]) => {
-  const summertSamvær = samværsuker
-    .flatMap(samværsuke =>
-      Object.values(samværsuke).flatMap((samværsdag: Samværsdag) => samværsdag.andeler),
-    )
-    .map(andel => samværsandelTilVerdi[andel])
-    .reduce((acc, andel) => acc + andel, 0);
-
-  const maksimalSamværsandel = samværsuker.length * 7 * 8;
-
-  const antallHeleDagerMedSamvær = Math.floor(summertSamvær / 8);
-
-  const rest = summertSamvær % 8;
-  const restSuffix = rest === 0 ? '' : '/8';
-
-  const prosentandel = summertSamvær / maksimalSamværsandel;
-
-  const visningstekstAntallDager = `${antallHeleDagerMedSamvær} dager og ${rest}${restSuffix} deler`;
-  const visningstekstProsentandel = `${Math.round(prosentandel * 1000) / 10}%`;
-  return `Samvær: ${visningstekstAntallDager} av totalt ${samværsuker.length} uker = ${visningstekstProsentandel}`;
-};
-
-export const Samværsavtale: React.FC<Props> = ({ samværsavtale }) => (
-  <div>
-    <Oppsummering samværsavtale={samværsavtale} />;
+export const Samværsavtale: React.FC<Props> = ({ beregnetSamvær }) => (
+  <div className={'blankett-samværsavtale'}>
+    {beregnetSamvær.uker.map(avsnitt => (
+      <>
+        {avsnitt.deloverskrift && utledDeloverskrift(avsnitt)}
+        {avsnitt.innhold && <p style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</p>}
+      </>
+    ))}
+    <div>{beregnetSamvær.oppsummering}</div>
   </div>
-);
-
-const Oppsummering: React.FC<Props> = ({ samværsavtale }) => (
-  <div className={'blankett-samværsavtale'}>{utledOppsummering(samværsavtale.uker)}</div>
 );

--- a/src/server/blankett/components/Samværsavtale.tsx
+++ b/src/server/blankett/components/Samværsavtale.tsx
@@ -7,13 +7,16 @@ interface Props {
 }
 
 export const Samværsavtale: React.FC<Props> = ({ beregnetSamvær }) => (
-  <div className={'blankett-samværsavtale'}>
+  <>
+    <div>
+      <strong>Samværsberegning</strong>
+    </div>
     {beregnetSamvær.uker.map(avsnitt => (
       <>
         {avsnitt.deloverskrift && utledDeloverskrift(avsnitt)}
         {avsnitt.innhold && <p style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</p>}
       </>
     ))}
-    <div>{beregnetSamvær.oppsummering}</div>
-  </div>
+    <div className={'blankett-samværsavtale-oppsummering'}>{beregnetSamvær.oppsummering}</div>
+  </>
 );

--- a/src/server/blankett/components/Samværsavtale.tsx
+++ b/src/server/blankett/components/Samværsavtale.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
 import {
   samværsandelTilVerdi,
-  Samværsavtale,
+  Samværsavtale as Avtale,
   Samværsdag,
   Samværsuke,
 } from '../../../typer/dokumentApiBlankett';
 
 interface Props {
-  avtale: Samværsavtale;
+  samværsavtale: Avtale;
 }
 
-export const SamværsavtaleVisning: React.FC<Props> = ({ avtale }) => (
-  <div className={'blankett-samværsavtale'}>{utledVisningstekstForSamværsavtale(avtale.uker)}</div>
-);
-
-const utledVisningstekstForSamværsavtale = (samværsuker: Samværsuke[]) => {
+const utledOppsummering = (samværsuker: Samværsuke[]) => {
   const summertSamvær = samværsuker
     .flatMap(samværsuke =>
       Object.values(samværsuke).flatMap((samværsdag: Samværsdag) => samværsdag.andeler),
@@ -35,3 +31,13 @@ const utledVisningstekstForSamværsavtale = (samværsuker: Samværsuke[]) => {
   const visningstekstProsentandel = `${Math.round(prosentandel * 1000) / 10}%`;
   return `Samvær: ${visningstekstAntallDager} av totalt ${samværsuker.length} uker = ${visningstekstProsentandel}`;
 };
+
+export const Samværsavtale: React.FC<Props> = ({ samværsavtale }) => (
+  <div>
+    <Oppsummering samværsavtale={samværsavtale} />;
+  </div>
+);
+
+const Oppsummering: React.FC<Props> = ({ samværsavtale }) => (
+  <div className={'blankett-samværsavtale'}>{utledOppsummering(samværsavtale.uker)}</div>
+);

--- a/src/server/blankett/components/Vilkårsvurdering.tsx
+++ b/src/server/blankett/components/Vilkårsvurdering.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { IVurdering, Samværsavtale } from '../../../typer/dokumentApiBlankett';
+import type { IVurdering } from '../../../typer/dokumentApiBlankett';
 import {
   Vilkårsresultat,
   Vilkår,
@@ -14,7 +14,6 @@ import { OppfyltIkon } from '../../components/ikoner/OppfyltIkon';
 
 interface Props {
   vurdering: IVurdering;
-  samværsavtaler?: Samværsavtale[];
 }
 
 const resultatIkon = (resultat: Vilkårsresultat) => {

--- a/src/server/lagManueltBrevHtml.tsx
+++ b/src/server/lagManueltBrevHtml.tsx
@@ -60,21 +60,19 @@ export const lagManueltBrevBaksHtml = (brevMedSignatur: IFritekstbrevMedSignatur
           brevOpprettetDato={brevMedSignatur.datoPlaceholder || dagensDatoFormatertLang()}
         />
         <h1>{brev.overskrift}</h1>
-        {brev.avsnitt?.map((avsnitt, _) => {
-          return (
-            <>
-              {avsnitt.deloverskrift && utledDeloverskrift(avsnitt)}
-              {avsnitt.innhold && <p style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</p>}
-            </>
-          );
-        })}
+        {brev.avsnitt?.map(avsnitt => (
+          <>
+            {avsnitt.deloverskrift && utledDeloverskrift(avsnitt)}
+            {avsnitt.innhold && <p style={{ whiteSpace: 'pre-wrap' }}>{avsnitt.innhold}</p>}
+          </>
+        ))}
         <div className="signatur">{utledBrevsignatur(erSamværsberegning, brevMedSignatur)}</div>
       </body>
     </html>,
   );
 };
 
-const utledDeloverskrift = (avsnitt: IAvsnitt) => {
+export const utledDeloverskrift = (avsnitt: IAvsnitt) => {
   switch (avsnitt.deloverskriftHeading) {
     case Heading.H1:
       return <h1>{avsnitt.deloverskrift}</h1>;

--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -58,7 +58,7 @@ export default `
     margin-bottom: 5px;
   }
   
-  .blankett-samværsavtale {
+  .blankett-samværsavtale-oppsummering {
     margin-bottom: 5px;
   }
   

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -1,3 +1,5 @@
+import { IAvsnitt } from './dokumentApiBrev';
+
 export interface IDokumentData {
   behandling: IBehandling;
   vilkår: IVilkår;
@@ -5,6 +7,7 @@ export interface IDokumentData {
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
   samværsavtaler: Samværsavtale[];
+  samværsavtalerV2: IAvsnitt[];
 }
 
 export interface IBehandling {
@@ -922,6 +925,11 @@ export interface Samværsavtale {
   behandlingId: string;
   behandlingBarnId: string;
   uker: Samværsuke[];
+}
+
+export interface SamværsavtaleV2 {
+  behandlingId: string;
+  behandlingBarnId: string;
 }
 
 export interface Samværsuke {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -6,8 +6,7 @@ export interface IDokumentData {
   personopplysninger: IPersonopplysninger;
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
-  samværsavtaler: Samværsavtale[];
-  samværsavtalerV2: IAvsnitt[];
+  beregnetSamvær: BeregnetSamvær[];
 }
 
 export interface IBehandling {
@@ -71,7 +70,7 @@ export interface ISøknadsdatoer {
 export type IAvslåVedtak = {
   resultatType: EBehandlingResultat.AVSLÅ;
   avslåBegrunnelse: string;
-  avslåÅrsak: EAvslagÅrsak;
+  avslåÅrsak: AvslagÅrsak;
 };
 
 export type IInnvilgeVedtakOvergangsstønad = {
@@ -167,13 +166,6 @@ export enum EBehandlingResultat {
   BEHANDLE_I_GOSYS = 'BEHANDLE_I_GOSYS',
 }
 
-export const behandlingResultatTilTekst: Record<EBehandlingResultat, string> = {
-  INNVILGE: 'Innvilge',
-  AVSLÅ: 'Avslå',
-  HENLEGGE: 'Henlegge',
-  BEHANDLE_I_GOSYS: 'Behandle i Gosys',
-};
-
 export enum EStønadType {
   OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
   BARNETILSYN = 'BARNETILSYN',
@@ -221,12 +213,6 @@ export interface IPeriode {
   årMånedTil: string;
 }
 
-export interface IPeriodeBarnetilsyn {
-  årMånedFra: string;
-  årMånedTil: string;
-  utgifter: number;
-  antallBarn: number;
-}
 export enum EPeriodetype {
   PERIODE_FØR_FØDSEL = 'PERIODE_FØR_FØDSEL',
   HOVEDPERIODE = 'HOVEDPERIODE',
@@ -396,13 +382,14 @@ export interface IMedlemskapRegistergrunnlag {
   nåværendeStatsborgerskap: string[];
   oppholdstatus: IOppholdstatus[];
   statsborgerskap: IStatsborgerskap[];
-  folkeregisterpersonstatus: Folkeregisterpersonstatus; //TODO: Definere typen et annet sted enn personopplysninger?
+  folkeregisterpersonstatus: Folkeregisterpersonstatus;
   innflytting: IInnflyttingTilNorge[];
   utflytting: IUtflyttingFraNorge[];
   medlUnntak: IGyldigeVedtakPerioderIMedl;
 }
 
 export type IGyldigeVedtakPerioderIMedl = { gyldigeVedtaksPerioder: IGyldigVedtakPeriode[] };
+
 export interface IGyldigVedtakPeriode {
   fraogmedDato: string;
   tilogmedDato: string;
@@ -432,10 +419,6 @@ export interface IVurdering {
   delvilkårsvurderinger: IDelvilkår[];
   endretAv: string;
   endretTid: string;
-}
-
-export interface Vurderingsfeilmelding {
-  [Key: string]: string;
 }
 
 export enum IRegelId {
@@ -499,6 +482,7 @@ export enum IRegelId {
   NAVKONTOR_VURDERING = 'NAVKONTOR_VURDERING',
   SAKSBEHANDLER_VURDERING = 'SAKSBEHANDLER_VURDERING',
 }
+
 export enum ISvarId {
   // Felles
   JA = 'JA',
@@ -544,6 +528,7 @@ export enum ISvarId {
   NOEN_MÅNEDER_OVERSTIGER_6G = 'NOEN_MÅNEDER_OVERSTIGER_6G',
   BRUKER_MOTTAR_IKKE_OVERGANGSSTØNAD = 'BRUKER_MOTTAR_IKKE_OVERGANGSSTØNAD',
 }
+
 export interface IVurderingDelvilkår {
   regelId: IRegelId;
   svar?: ISvarId;
@@ -671,6 +656,7 @@ export const vilkårTypeTilTekst: Record<VilkårType, string> = {
   ER_UTDANNING_HENSIKTSMESSIG: 'Vilkår om utdanningens nødvendighet og hensiktsmessighet',
   RETT_TIL_OVERGANGSSTØNAD: 'Vilkåret om rett til overgangsstønad',
 };
+
 // ------ VILKÅRGRUPPE
 /**
  * Gjør det mulig å splitte opp vurderinger i eks Medlemskap, Aleneomsorg, etc.
@@ -755,6 +741,7 @@ export const svarIdTilTekst: Record<ISvarId, string> = {
   MEDLEM_MER_ENN_5_ÅR_EØS_ANNEN_FORELDER_TRYGDEDEKKET_I_NORGE:
     'Ja, EØS-borger fyller vilkåret om 5 års forutgående medlemskap etter bestemmelsene i annet EU/EØS-land, og den andre forelderen er EØS-borger og trygdedekket i Norge som yrkesaktiv',
 };
+
 export const delvilkårTypeTilTekst: Record<IRegelId, string> = {
   SØKER_MEDLEM_I_FOLKETRYGDEN: 'Har bruker vært medlem i folketrygden i de siste 5 årene?',
   BOR_OG_OPPHOLDER_SEG_I_NORGE: 'Bor og oppholder bruker og barna seg i Norge?',
@@ -897,7 +884,7 @@ export const opplysningskildeTilTekst: Record<Opplysningskilde, string> = {
   OPPLYSNINGER_INTERNE_KONTROLLER: 'Opplysninger fra intern kontroll',
 };
 
-export enum EAvslagÅrsak {
+export enum AvslagÅrsak {
   BARN_OVER_ÅTTE_ÅR = 'BARN_OVER_ÅTTE_ÅR',
   MANGLENDE_OPPLYSNINGER = 'MANGLENDE_OPPLYSNINGER',
   STØNADSTID_OPPBRUKT = 'STØNADSTID_OPPBRUKT',
@@ -905,15 +892,7 @@ export enum EAvslagÅrsak {
   KORTVARIG_AVBRUDD_JOBB = 'KORTVARIG_AVBRUDD_JOBB',
 }
 
-export const årsakerTilAvslag: EAvslagÅrsak[] = [
-  EAvslagÅrsak.BARN_OVER_ÅTTE_ÅR,
-  EAvslagÅrsak.MANGLENDE_OPPLYSNINGER,
-  EAvslagÅrsak.STØNADSTID_OPPBRUKT,
-  EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER,
-  EAvslagÅrsak.KORTVARIG_AVBRUDD_JOBB,
-];
-
-export const avslagÅrsakTilTekst: Record<EAvslagÅrsak, string> = {
+export const avslagÅrsakTilTekst: Record<AvslagÅrsak, string> = {
   BARN_OVER_ÅTTE_ÅR: 'Barnet er over 8 år',
   MANGLENDE_OPPLYSNINGER: 'Manglende opplysninger',
   STØNADSTID_OPPBRUKT: 'Stønadstiden er brukt opp',
@@ -921,41 +900,8 @@ export const avslagÅrsakTilTekst: Record<EAvslagÅrsak, string> = {
   KORTVARIG_AVBRUDD_JOBB: 'Kortvarig avbrudd jobb',
 };
 
-export interface Samværsavtale {
-  behandlingId: string;
+export interface BeregnetSamvær {
   behandlingBarnId: string;
-  uker: Samværsuke[];
+  uker: IAvsnitt[];
+  oppsummering: string;
 }
-
-export interface SamværsavtaleV2 {
-  behandlingId: string;
-  behandlingBarnId: string;
-}
-
-export interface Samværsuke {
-  mandag: Samværsdag;
-  tirsdag: Samværsdag;
-  onsdag: Samværsdag;
-  torsdag: Samværsdag;
-  fredag: Samværsdag;
-  lørdag: Samværsdag;
-  søndag: Samværsdag;
-}
-
-export interface Samværsdag {
-  andeler: Samværsandel[];
-}
-
-export enum Samværsandel {
-  KVELD_NATT = 'KVELD_NATT',
-  MORGEN = 'MORGEN',
-  BARNEHAGE_SKOLE = 'BARNEHAGE_SKOLE',
-  ETTERMIDDAG = 'ETTERMIDDAG',
-}
-
-export const samværsandelTilVerdi: Record<Samværsandel, number> = {
-  KVELD_NATT: 4,
-  MORGEN: 1,
-  BARNEHAGE_SKOLE: 2,
-  ETTERMIDDAG: 1,
-};


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24882)
Skal vise et fullstendig bilde av valgene som ble gjort i samværskalkulatoren i vilkårsfanen. Eksempel:
![Skjermbilde 2025-05-12 kl  09 42 59](https://github.com/user-attachments/assets/bb6ca4e7-408b-46e9-803c-ce86b168ece6)
