### PR TITLE
bruker ikke lenger feltet enhet

### DIFF
--- a/src/server/components/SaksbehandlerSignatur.tsx
+++ b/src/server/components/SaksbehandlerSignatur.tsx
@@ -5,7 +5,6 @@ interface Props {
   saksbehandlerEnhet?: string;
   besluttersignatur?: string;
   beslutterEnhet?: string;
-  deprecatedEnhet?: string;
 }
 
 export const SaksbehandlerSignatur: React.FC<Props> = ({
@@ -13,7 +12,6 @@ export const SaksbehandlerSignatur: React.FC<Props> = ({
   saksbehandlerEnhet,
   besluttersignatur,
   beslutterEnhet,
-  deprecatedEnhet,
 }) => (
   <div>
     <p style={{ float: 'left' }}>
@@ -42,7 +40,7 @@ export const SaksbehandlerSignatur: React.FC<Props> = ({
         >
           {saksbehandlersignatur}
         </span>
-        <span>{saksbehandlerEnhet ?? deprecatedEnhet ?? 'Nav arbeid og ytelser'}</span>
+        <span>{saksbehandlerEnhet ?? 'Nav arbeid og ytelser'}</span>
       </span>
     </p>
   </div>

--- a/src/server/hentAvansertDokumentHtml.tsx
+++ b/src/server/hentAvansertDokumentHtml.tsx
@@ -34,7 +34,6 @@ export const hentAvansertDokumentHtml = async (
     saksbehandlerEnhet,
     besluttersignatur,
     beslutterEnhet,
-    enhet,
     skjulBeslutterSignatur,
     datoPlaceholder,
   } = brevMedSignatur;
@@ -81,7 +80,6 @@ export const hentAvansertDokumentHtml = async (
               saksbehandlerEnhet={saksbehandlerEnhet}
               besluttersignatur={skjulBeslutterSignatur ? undefined : besluttersignatur}
               beslutterEnhet={beslutterEnhet}
-              deprecatedEnhet={enhet}
             />
           </div>
         </body>

--- a/src/typer/dokumentApiBrev.ts
+++ b/src/typer/dokumentApiBrev.ts
@@ -27,14 +27,12 @@ export interface IOverstyrtDelmalblokk {
   skalOverstyre: boolean;
 }
 
-// TODO: Fjern enhet og deprecatedEnhet
 export interface IBrevMedSignatur {
   brevFraSaksbehandler: IAvansertDokumentVariabler;
   saksbehandlersignatur: string;
   saksbehandlerEnhet?: string;
   besluttersignatur?: string;
   beslutterEnhet?: string;
-  enhet?: string;
   skjulBeslutterSignatur?: boolean;
   datoPlaceholder?: string;
 }


### PR DESCRIPTION
Opprydning etter [oppgaven om å oppdatere saksbehandler- og besluttersignatur](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24673)

Kan ikke merges før BA endrer feltnavn til saksbehandlerEnhet i BA-sak (mulig de må endre i ks-sak også):
https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt#L480