### PR TITLE
skal fjerne clogging av warnings i logg ved å skrive om til gyldig css

### DIFF
--- a/src/server/utils/css.ts
+++ b/src/server/utils/css.ts
@@ -82,10 +82,8 @@ export default `
     padding:0;
   }
   
-  h3, h4 {
-    &.blankett {
-      margin-bottom: 3px;
-    }
+  h3.blankett, h4.blankett {
+    margin-bottom: 3px;
   }
   
   table, th, td {


### PR DESCRIPTION
Får veldig mange logginnslag av typen `(#inline_style_1) Found & (other) where an identifier was expected at line 85. Skipping declaration.`

Skriver om til gyldig css for å forhåpentligvis få litt færre warnings fra familie-dokument