### PR TITLE
NAV-25543: Justerer mapping av søkers og annen forelders aktivitet

### DIFF
--- a/src/baks/formateringer.ts
+++ b/src/baks/formateringer.ts
@@ -1,14 +1,14 @@
 import { Feil } from '../server/utils/Feil';
-import type {
+import {
   BegrunnelseMedData,
   FlettefeltBlock,
   MarkDef,
   ValgfeltBlock,
   ValgfeltMuligheter,
+  Valgfelttype,
 } from './typer';
-import { Valgfelttype } from './typer';
 import {
-  annenForeldersAktivitetValg,
+  hentAnnenForeldersAktivitetValg,
   hentBarnetBarnaDineDittValg,
   hentBarnetBarnaValg,
   hentDegDereEllerSegValg,
@@ -18,7 +18,7 @@ import {
   hentForBarnFodtValg,
   hentFraDatoValg,
   hentSøkerOgEllerBarnetBarnaValg,
-  søkersAktivitetValg,
+  hentSøkersAktivitetValg,
 } from './formateringsvalg';
 
 export const formaterValgfelt = (valgfeltBlock: ValgfeltBlock, data: BegrunnelseMedData) => {
@@ -44,9 +44,9 @@ export const formaterValgfelt = (valgfeltBlock: ValgfeltBlock, data: Begrunnelse
       return valgfeltSerializer(valgfeltBlock, hentDuFårEllerHarRettTilUtvidetValg(data), data);
     case Valgfelttype.EOS_SOKERS_AKTIVITET_1:
     case Valgfelttype.EOS_SOKERS_AKTIVITET_2:
-      return valgfeltSerializer(valgfeltBlock, søkersAktivitetValg(data), data);
+      return valgfeltSerializer(valgfeltBlock, hentSøkersAktivitetValg(data), data);
     case Valgfelttype.EOS_ANNEN_FORELDERS_AKTIVITET:
-      return valgfeltSerializer(valgfeltBlock, annenForeldersAktivitetValg(data), data);
+      return valgfeltSerializer(valgfeltBlock, hentAnnenForeldersAktivitetValg(data), data);
     default:
       throw new Feil(
         `Ukjent formulering fra sanity. Det er ikke laget noen funksjonalitet for ${valgfeltBlock.apiNavn}`,

--- a/src/baks/typer.ts
+++ b/src/baks/typer.ts
@@ -35,6 +35,7 @@ export interface IEØSBegrunnelsedata {
   maalform: Maalform;
   type: Begrunnelsetype.EØS_BEGRUNNELSE;
   gjelderSoker?: boolean;
+  erAnnenForelderOmfattetAvNorskLovgivning?: boolean;
 }
 
 export interface IFritekst {


### PR DESCRIPTION
Favro: [NAV-25543](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25543)

Sørger for at vi mapper `søkersAktivitet` slik vi vanligvis mapper `annenForeldersAktivitet`, og `annenForeldersAktivitet` slik vi vanligvis mapper `søkersAktivitet` dersom feltet `erAnnenForelderOmfattetAvNorskLovgivning` er satt til `true`.

For at endringen skal ha effekt har jeg også lagt til nødvendige valgfelt i sanity for tekstene:
* [EØS søkers aktivitet tekst 1](https://familie-brev.sanity.studio/ba-brev/structure/begrunnelseBa;eos;innvilget;begrunnelse-7a7cccd6-4c1c-4e0f-855d-899942129841;c76d7bb2-2871-492f-8c13-95c31d2dd0cb%2Ctype%3Dvalgfelt%2CparentRefPath%3Dnynorsk%255B_key%253D%253D%2522befe3e559c66%2522%255D.children%255B_key%253D%253D%25220cf0944ef148%2522%255D.valgReferanse)
* [EØS annen forelders aktivitet](https://familie-brev.sanity.studio/ba-brev/structure/begrunnelseBa;eos;innvilget;begrunnelse-7a7cccd6-4c1c-4e0f-855d-899942129841;44a17a41-a760-44f7-8d7d-a3cf1676b85a%2Ctype%3Dvalgfelt%2CparentRefPath%3Dnynorsk%255B_key%253D%253D%2522befe3e559c66%2522%255D.children%255B_key%253D%253D%25221a8497e0b502%2522%255D.valgReferanse)