### PR TITLE
Fix: Fjerne selvstendig rett logikk for annen forelders aktivitet

### DIFF
--- a/src/baks/formateringsvalg.ts
+++ b/src/baks/formateringsvalg.ts
@@ -246,10 +246,7 @@ export const hentAnnenForeldersAktivitetValg = (data: BegrunnelseMedData) => {
     throw lagFeilStøttesKunForEØS(valgfeltNavn, data);
   }
 
-  // Dersom annen forelder er omfattet av norsk lovgivning (søker har selvstendig rett) skal vi mappe annen forelders aktivitet slik vi vanligvis mapper søkers aktivitet
-  return data.erAnnenForelderOmfattetAvNorskLovgivning
-    ? søkersAktivitetValg(data.annenForeldersAktivitet, data.apiNavn, valgfeltNavn)
-    : annenForeldersAktivitetValg(data.annenForeldersAktivitet, data.apiNavn, valgfeltNavn);
+  return annenForeldersAktivitetValg(data.annenForeldersAktivitet, data.apiNavn, valgfeltNavn);
 };
 
 export const annenForeldersAktivitetValg = (


### PR DESCRIPTION
Favro: [NAV-25543](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25543)

Det viser seg at vi fortsatt ønsker at annen forelders aktivitet mappes til sanity tekster slik vi alltid har gjort, og at det kun er søkers aktivitet vi ønsker å mappe annerledes ved selvstendig rett.

Korrigerer kode lagt inn i denne PR'en: https://github.com/navikt/familie-brev/pull/795