### PR TITLE
skal vise alle mottakere av brev øverst i brevet

### DIFF
--- a/src/server/components/Header.tsx
+++ b/src/server/components/Header.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { NavIkon } from './ikoner/navIkon';
-import type { Flettefelt } from '../../typer/dokumentApiBrev';
+import {
+  Brevmottakere,
+  BrevmottakerOrganisasjon,
+  BrevmottakerPrivatperson,
+  BrevmottakerRolle,
+  Flettefelt,
+} from '../../typer/dokumentApiBrev';
 import { validerFlettefelt } from '../utils/valideringer/validerFlettefelt';
 import { Maalform } from '../../typer/sanitygrensesnitt';
 
-interface HeaderProps {
+interface Props {
   tittel: string;
   navn: Flettefelt;
   fodselsnummer: Flettefelt;
@@ -12,58 +18,42 @@ interface HeaderProps {
   visLogo?: boolean;
   apiNavn: string;
   maalform: Maalform;
-  organisasjonsnummer?: Flettefelt;
-  gjelder?: Flettefelt;
   datoPlaceholder?: string;
+  brevmottakere?: Brevmottakere;
 }
 
-export const Header = (props: HeaderProps) => {
-  const {
-    tittel,
-    navn,
-    fodselsnummer,
-    visLogo,
-    brevOpprettetDato,
-    apiNavn,
-    maalform,
-    organisasjonsnummer,
-    gjelder,
-    datoPlaceholder,
-  } = props;
-
+export const Header: React.FC<Props> = ({
+  tittel,
+  navn,
+  fodselsnummer,
+  visLogo,
+  brevOpprettetDato,
+  apiNavn,
+  maalform,
+  datoPlaceholder,
+  brevmottakere,
+}) => {
   validerFlettefelt(navn, 'navn', apiNavn, false);
   validerFlettefelt(fodselsnummer, 'fodselsnummer', apiNavn, false);
   validerFlettefelt(brevOpprettetDato, 'brevOpprettetDato', apiNavn, false);
 
-  organisasjonsnummer &&
-    validerFlettefelt(organisasjonsnummer, 'organisasjonsnummer', apiNavn, false);
-  gjelder && validerFlettefelt(gjelder, 'gjelder', apiNavn, false);
-
-  const brevDato = () => {
-    return `Dato: ${datoPlaceholder || brevOpprettetDato[0]}`;
-  };
+  const harVergeEllerFullmektig = utledHarVergeEllerFullmektig(brevmottakere);
 
   return (
     <div className={'header'}>
       <div className="ikon-og-dato-wrapper">
         <div className="ikon-og-dato">
           {visLogo && <NavIkon />}
-          <p>{brevDato()}</p>
+          <p>{utledBrevDato(brevOpprettetDato, datoPlaceholder)}</p>
         </div>
       </div>
       <div className={'tittel-og-personinfo'}>
         <h2 className="tittel">{tittel}</h2>
         <div className="kolonner">
           <div className="personinfo">
-            <div>
-              {navnTittel(maalform)}: {navn}
-            </div>
-            {organisasjonsnummer && <div>Organisasjonsnummer: {organisasjonsnummer}</div>}
-            {gjelder && (
-              <div>
-                {gjelderTittel(maalform)}: {gjelder}
-              </div>
-            )}
+            <BrevmottakereOrganisasjoner mottakere={brevmottakere?.organisasjoner} />
+            <BrevmottakerePrivatpersoner mottakere={brevmottakere?.personer} />
+            <div>{utledHvemBrevetGjelderFor(maalform, navn, harVergeEllerFullmektig)}</div>
             <div>Fødselsnummer: {fodselsnummer}</div>
           </div>
         </div>
@@ -72,20 +62,53 @@ export const Header = (props: HeaderProps) => {
   );
 };
 
-const navnTittel = (maalform: Maalform): string => {
-  switch (maalform) {
-    case Maalform.NB:
-      return 'Navn';
-    case Maalform.NN:
-      return 'Namn';
-  }
-};
+const BrevmottakereOrganisasjoner: React.FC<{
+  mottakere: BrevmottakerOrganisasjon[] | undefined;
+}> = ({ mottakere }) => (
+  <>
+    {mottakere?.map((organisasjon, index) => (
+      <div key={index}>{`Fullmektig: ${organisasjon.navnHosOrganisasjon}`}</div>
+    ))}
+  </>
+);
 
-const gjelderTittel = (maalform: Maalform): string => {
+const BrevmottakerePrivatpersoner: React.FC<{
+  mottakere: BrevmottakerPrivatperson[] | undefined;
+}> = ({ mottakere }) => (
+  <>
+    {mottakere?.map((person, index) => (
+      <div
+        key={index}
+      >{`${person.mottakerRolle === BrevmottakerRolle.VERGE ? 'Verge:' : 'Fullmektig:'} ${person.navn}`}</div>
+    ))}
+  </>
+);
+
+const utledHarVergeEllerFullmektig = (brevmottakere: Brevmottakere | undefined) =>
+  brevmottakere !== undefined &&
+  (brevmottakere.personer.length > 0 || brevmottakere.organisasjoner.length > 0);
+
+const utledBrevDato = (opprettetDato: Flettefelt, placeholder?: string | undefined) =>
+  `Dato: ${placeholder || opprettetDato[0]}`;
+
+const utledHvemBrevetGjelderFor = (
+  maalform: Maalform,
+  navn: Flettefelt,
+  harVergeEllerFullmektig: boolean,
+): string => {
+  if (harVergeEllerFullmektig) {
+    switch (maalform) {
+      case Maalform.NB:
+        return `Saken gjelder: ${navn}`;
+      case Maalform.NN:
+        return `Saka gjeld: ${navn}`;
+    }
+  }
+
   switch (maalform) {
     case Maalform.NB:
-      return 'Gjelder';
+      return `Navn: ${navn}`;
     case Maalform.NN:
-      return 'Gjeld';
+      return `Namn: ${navn}`;
   }
 };

--- a/src/server/components/Header.tsx
+++ b/src/server/components/Header.tsx
@@ -88,7 +88,9 @@ const BrevmottakerePrivatpersoner: React.FC<{
 
 const utledHarVergeEllerFullmektig = (brevmottakere: Brevmottakere | undefined) =>
   brevmottakere !== undefined &&
-  (brevmottakere.personer.length > 0 || brevmottakere.organisasjoner.length > 0);
+  (brevmottakere.personer.filter(mottaker => mottaker.mottakerRolle !== BrevmottakerRolle.BRUKER)
+    .length > 0 ||
+    brevmottakere.organisasjoner.length > 0);
 
 const utledBrevDato = (opprettetDato: Flettefelt, placeholder?: string | undefined) =>
   `Dato: ${placeholder || opprettetDato[0]}`;

--- a/src/server/components/Header.tsx
+++ b/src/server/components/Header.tsx
@@ -76,11 +76,13 @@ const BrevmottakerePrivatpersoner: React.FC<{
   mottakere: BrevmottakerPrivatperson[] | undefined;
 }> = ({ mottakere }) => (
   <>
-    {mottakere?.map((person, index) => (
-      <div
-        key={index}
-      >{`${person.mottakerRolle === BrevmottakerRolle.VERGE ? 'Verge:' : 'Fullmektig:'} ${person.navn}`}</div>
-    ))}
+    {mottakere
+      ?.filter(person => person.mottakerRolle !== BrevmottakerRolle.BRUKER)
+      .map((person, index) => (
+        <div
+          key={index}
+        >{`${person.mottakerRolle === BrevmottakerRolle.VERGE ? 'Verge:' : 'Fullmektig:'} ${person.navn}`}</div>
+      ))}
   </>
 );
 

--- a/src/server/components/HeaderDeprecated.tsx
+++ b/src/server/components/HeaderDeprecated.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { NavIkon } from './ikoner/navIkon';
+import { Flettefelt } from '../../typer/dokumentApiBrev';
+import { validerFlettefelt } from '../utils/valideringer/validerFlettefelt';
+import { Maalform } from '../../typer/sanitygrensesnitt';
+
+interface Props {
+  tittel: string;
+  navn: Flettefelt;
+  fodselsnummer: Flettefelt;
+  brevOpprettetDato: Flettefelt;
+  visLogo?: boolean;
+  apiNavn: string;
+  maalform: Maalform;
+  organisasjonsnummer?: Flettefelt;
+  gjelder?: Flettefelt;
+  datoPlaceholder?: string;
+}
+
+export const HeaderDeprecated: React.FC<Props> = ({
+  tittel,
+  navn,
+  fodselsnummer,
+  visLogo,
+  brevOpprettetDato,
+  apiNavn,
+  maalform,
+  organisasjonsnummer,
+  gjelder,
+  datoPlaceholder,
+}) => {
+  validerFlettefelt(navn, 'navn', apiNavn, false);
+  validerFlettefelt(fodselsnummer, 'fodselsnummer', apiNavn, false);
+  validerFlettefelt(brevOpprettetDato, 'brevOpprettetDato', apiNavn, false);
+
+  organisasjonsnummer &&
+    validerFlettefelt(organisasjonsnummer, 'organisasjonsnummer', apiNavn, false);
+  gjelder && validerFlettefelt(gjelder, 'gjelder', apiNavn, false);
+
+  const brevDato = () => {
+    return `Dato: ${datoPlaceholder || brevOpprettetDato[0]}`;
+  };
+
+  return (
+    <div className={'header'}>
+      <div className="ikon-og-dato-wrapper">
+        <div className="ikon-og-dato">
+          {visLogo && <NavIkon />}
+          <p>{brevDato()}</p>
+        </div>
+      </div>
+      <div className={'tittel-og-personinfo'}>
+        <h2 className="tittel">{tittel}</h2>
+        <div className="kolonner">
+          <div className="personinfo">
+            <div>
+              {navnTittel(maalform)}: {navn}
+            </div>
+            {organisasjonsnummer && <div>Organisasjonsnummer: {organisasjonsnummer}</div>}
+            {gjelder && (
+              <div>
+                {gjelderTittel(maalform)}: {gjelder}
+              </div>
+            )}
+            <div>Fødselsnummer: {fodselsnummer}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const navnTittel = (maalform: Maalform): string => {
+  switch (maalform) {
+    case Maalform.NB:
+      return 'Navn';
+    case Maalform.NN:
+      return 'Namn';
+  }
+};
+
+const gjelderTittel = (maalform: Maalform): string => {
+  switch (maalform) {
+    case Maalform.NB:
+      return 'Gjelder';
+    case Maalform.NN:
+      return 'Gjeld';
+  }
+};

--- a/src/server/hentAvansertDokumentHtml.tsx
+++ b/src/server/hentAvansertDokumentHtml.tsx
@@ -6,11 +6,12 @@ import { client } from './sanity/sanityClient';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Context } from './utils/Context';
 import css from './utils/css';
-import { Header } from './components/Header';
+import { HeaderDeprecated } from './components/HeaderDeprecated';
 import { Maalform } from '../typer/sanitygrensesnitt';
 import { DokumentType } from '../typer/dokumentType';
 import { dagensDatoFormatert } from './utils/util';
 import { SaksbehandlerSignatur } from './components/SaksbehandlerSignatur';
+import { Header } from './components/Header';
 
 enum HtmlLang {
   NB = 'nb',
@@ -58,16 +59,30 @@ export const hentAvansertDokumentHtml = async (
         </head>
         <body className={'body'}>
           <div>
-            <Header
-              visLogo={true}
-              tittel={tittel}
-              navn={dokumentVariabler?.flettefelter?.navn}
-              fodselsnummer={dokumentVariabler?.flettefelter?.fodselsnummer}
-              apiNavn={dokumentApiNavn}
-              brevOpprettetDato={[dagensDatoFormatert()]}
-              maalform={maalform}
-              datoPlaceholder={datoPlaceholder}
-            />
+            {dokumentVariabler.featureToggleBrukNyBrevHeader ? (
+              <Header
+                visLogo={true}
+                tittel={tittel}
+                navn={dokumentVariabler?.flettefelter?.navn}
+                fodselsnummer={dokumentVariabler?.flettefelter?.fodselsnummer}
+                apiNavn={dokumentApiNavn}
+                brevOpprettetDato={[dagensDatoFormatert()]}
+                maalform={maalform}
+                datoPlaceholder={datoPlaceholder}
+                brevmottakere={dokumentVariabler?.brevmottakere}
+              />
+            ) : (
+              <HeaderDeprecated
+                visLogo={true}
+                tittel={tittel}
+                navn={dokumentVariabler?.flettefelter?.navn}
+                fodselsnummer={dokumentVariabler?.flettefelter?.fodselsnummer}
+                apiNavn={dokumentApiNavn}
+                brevOpprettetDato={[dagensDatoFormatert()]}
+                maalform={maalform}
+                datoPlaceholder={datoPlaceholder}
+              />
+            )}
             <AvansertDokument
               apiNavn={dokumentApiNavn}
               avanserteDokumentVariabler={dokumentVariabler}

--- a/src/server/hentDokumentHtml.tsx
+++ b/src/server/hentDokumentHtml.tsx
@@ -6,7 +6,7 @@ import { client } from './sanity/sanityClient';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Context } from './utils/Context';
 import css from './utils/css';
-import { Header } from './components/Header';
+import { HeaderDeprecated } from './components/HeaderDeprecated';
 import { Maalform } from '../typer/sanitygrensesnitt';
 import { Feil } from './utils/Feil';
 import { ServerStyleSheet } from 'styled-components';
@@ -55,7 +55,7 @@ export const hentDokumentHtml = async (
         </head>
         <body className={'body'}>
           <div>
-            <Header
+            <HeaderDeprecated
               visLogo={true}
               tittel={tittel}
               navn={apiDokument?.flettefelter?.navn}

--- a/src/typer/dokumentApiBrev.ts
+++ b/src/typer/dokumentApiBrev.ts
@@ -20,6 +20,32 @@ export interface IAvansertDokumentVariabler {
   valgfelter: IValgfelter;
   htmlfelter: IHtmlfelter;
   overstyrtDelmalblokk?: IOverstyrtDelmalblokk;
+  brevmottakere?: Brevmottakere;
+  featureToggleBrukNyBrevHeader?: boolean;
+}
+
+export interface Brevmottakere {
+  personer: BrevmottakerPrivatperson[];
+  organisasjoner: BrevmottakerOrganisasjon[];
+}
+
+export interface BrevmottakerPrivatperson {
+  personIdent: string;
+  navn: string;
+  mottakerRolle: BrevmottakerRolle;
+}
+
+export interface BrevmottakerOrganisasjon {
+  organisasjonsnummer: string;
+  navnHosOrganisasjon: string;
+  mottakerRolle: BrevmottakerRolle.FULLMEKTIG;
+}
+
+export enum BrevmottakerRolle {
+  BRUKER = 'BRUKER',
+  VERGE = 'VERGE',
+  FULLMEKTIG = 'FULLMEKTIG',
+  FULLMAKT = 'FULLMAKT',
 }
 
 export interface IOverstyrtDelmalblokk {


### PR DESCRIPTION
Vi ønsker å vise alle brevmottakere øverst i brevene vi sender slik at de følger Nav sin brevstandard. Den kan man lese mer om her: https://aksel.nav.no/god-praksis/artikler/visuelle-retningslinjer-for-brev

Denne PRen henger sammen med en endring i ef-sak frontend: https://github.com/navikt/familie-ef-sak-frontend/pull/3162

