### PR TITLE
Ikke vis saksbehandlersignatur hvis den ikke er satt

### DIFF
--- a/src/server/components/SaksbehandlerSignatur.tsx
+++ b/src/server/components/SaksbehandlerSignatur.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface Props {
-  saksbehandlersignatur: string;
+  saksbehandlersignatur?: string;
   saksbehandlerEnhet?: string;
   besluttersignatur?: string;
   beslutterEnhet?: string;
@@ -33,13 +33,15 @@ export const SaksbehandlerSignatur: React.FC<Props> = ({
         </span>
       )}
       <span style={{ display: 'inline-block' }}>
-        <span
-          style={{
-            display: 'block',
-          }}
-        >
-          {saksbehandlersignatur}
-        </span>
+        {saksbehandlersignatur && (
+          <span
+            style={{
+              display: 'block',
+            }}
+          >
+            {saksbehandlersignatur}
+          </span>
+        )}
         <span>{saksbehandlerEnhet ?? 'Nav arbeid og ytelser'}</span>
       </span>
     </p>

--- a/src/typer/dokumentApiBrev.ts
+++ b/src/typer/dokumentApiBrev.ts
@@ -69,7 +69,7 @@ export interface IOverstyrtDelmalblokk {
 
 export interface IBrevMedSignatur {
   brevFraSaksbehandler: IAvansertDokumentVariabler;
-  saksbehandlersignatur: string;
+  saksbehandlersignatur?: string;
   saksbehandlerEnhet?: string;
   besluttersignatur?: string;
   beslutterEnhet?: string;


### PR DESCRIPTION
Saksbehandlers signatur skal ikke vises i skjermet barn-fagsaker. Tillater at den kan være null, og viser ikke saksbehandlersignatur hvis den ikke er satt