### PR TITLE
Bytter ut axios med fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,14 @@
     "@navikt/familie-logging": "7.0.7",
     "@portabletext/react": "6.0.3",
     "@sanity/client": "7.20.0",
-    "axios": "1.15.0",
     "date-fns": "4.1.0",
     "dotenv": "17.3.1",
     "express": "5.2.1",
     "express-session": "1.19.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "ts-node": "10.9.2",
-    "styled-components": "6.3.12"
+    "styled-components": "6.3.12",
+    "ts-node": "10.9.2"
   },
   "devDependencies": {
     "@types/express": "5.0.6",

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -2,7 +2,7 @@ import { hentMiljøvariabler } from '../environment';
 import { Feil } from './Feil';
 import { logInfo } from '@navikt/familie-logging';
 
-export const genererPdf = async (html: string): Promise<ArrayBuffer> => {
+export const genererPdf = async (html: string): Promise<Buffer> => {
   const url = `${hentMiljøvariabler().FAMILIE_DOKUMENT_API_URL}/api/html-til-pdf`;
 
   logInfo(`Generer pdf mot ${url}`);
@@ -20,5 +20,5 @@ export const genererPdf = async (html: string): Promise<ArrayBuffer> => {
     throw new Feil(`Feil mot familie-dokument`, 500);
   }
 
-  return res.arrayBuffer();
+  return Buffer.from(await res.arrayBuffer());
 };

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -1,5 +1,3 @@
-import type { AxiosResponse } from 'axios';
-import axios from 'axios';
 import { hentMiljøvariabler } from '../environment';
 import { Feil } from './Feil';
 import { logInfo } from '@navikt/familie-logging';
@@ -8,16 +6,19 @@ export const genererPdf = async (html: string): Promise<ArrayBuffer> => {
   const url = `${hentMiljøvariabler().FAMILIE_DOKUMENT_API_URL}/api/html-til-pdf`;
 
   logInfo(`Generer pdf mot ${url}`);
-  return axios
-    .post(url, html, {
-      responseType: 'arraybuffer',
-      headers: {
-        'Content-Type': 'text/html',
-        Accept: 'application/pdf',
-      },
-    })
-    .then((res: AxiosResponse<ArrayBuffer>) => res.data)
-    .catch(error => {
-      throw new Feil(`Feil mot familie-dokument`, 500, error);
-    });
+
+  const res = await fetch(url, {
+    method: 'POST',
+    body: html,
+    headers: {
+      'Content-Type': 'text/html',
+      Accept: 'application/pdf',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Feil(`Feil mot familie-dokument`, 500);
+  }
+
+  return res.arrayBuffer();
 };

--- a/src/server/utils/apiBlankett.ts
+++ b/src/server/utils/apiBlankett.ts
@@ -1,5 +1,3 @@
-import type { AxiosResponse } from 'axios';
-import axios from 'axios';
 import { hentMiljøvariabler } from '../environment';
 import type { Meta } from '@navikt/familie-logging';
 import { logInfo } from '@navikt/familie-logging';
@@ -8,18 +6,21 @@ export const genererPdfBlankett = async (html: string, meta: Meta): Promise<Arra
   const url = `${hentMiljøvariabler().FAMILIE_DOKUMENT_API_URL}/api/html-til-pdf`;
 
   logInfo(`Generer pdf mot ${url}`, meta);
-  return axios
-    .post(url, html, {
-      responseType: 'arraybuffer',
-      headers: {
-        'Content-Type': 'text/html',
-        Accept: 'application/pdf',
-        'Nav-Consumer-Id': 'familie-ef-blankett',
-      },
-    })
-    .then((res: AxiosResponse<ArrayBuffer>) => res.data)
-    .catch(error => {
-      logInfo('Feil mot familie-dokument', meta);
-      throw error;
-    });
+
+  const res = await fetch(url, {
+    method: 'POST',
+    body: html,
+    headers: {
+      'Content-Type': 'text/html',
+      Accept: 'application/pdf',
+      'Nav-Consumer-Id': 'familie-ef-blankett',
+    },
+  });
+
+  if (!res.ok) {
+    logInfo('Feil mot familie-dokument', meta);
+    throw new Error(`Feil mot familie-dokument: ${res.status}`);
+  }
+
+  return res.arrayBuffer();
 };

--- a/src/server/utils/apiBlankett.ts
+++ b/src/server/utils/apiBlankett.ts
@@ -2,7 +2,7 @@ import { hentMiljøvariabler } from '../environment';
 import type { Meta } from '@navikt/familie-logging';
 import { logInfo } from '@navikt/familie-logging';
 
-export const genererPdfBlankett = async (html: string, meta: Meta): Promise<ArrayBuffer> => {
+export const genererPdfBlankett = async (html: string, meta: Meta): Promise<Buffer> => {
   const url = `${hentMiljøvariabler().FAMILIE_DOKUMENT_API_URL}/api/html-til-pdf`;
 
   logInfo(`Generer pdf mot ${url}`, meta);
@@ -22,5 +22,5 @@ export const genererPdfBlankett = async (html: string, meta: Meta): Promise<Arra
     throw new Error(`Feil mot familie-dokument: ${res.status}`);
   }
 
-  return res.arrayBuffer();
+  return Buffer.from(await res.arrayBuffer());
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,11 +875,6 @@ async@^3.2.3:
   resolved "https://registry.npmjs.org/async/-/async-3.2.5.tgz"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -891,15 +886,6 @@ axe-core@^4.10.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.1.tgz#7d2589b0183f05b0f23e55c2f4cdf97b5bdc66d9"
   integrity sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==
-
-axios@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
-  dependencies:
-    follow-redirects "^1.15.11"
-    form-data "^4.0.5"
-    proxy-from-env "^2.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -1129,13 +1115,6 @@ colorette@^2.0.20:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^14.0.3:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
@@ -1318,11 +1297,6 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -1926,7 +1900,7 @@ fn.name@1.x.x:
   resolved "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.15.11, follow-redirects@^1.15.9:
+follow-redirects@^1.15.9:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -1937,17 +1911,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2790,22 +2753,10 @@ merge-descriptors@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
   integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
 mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
 
 mime-types@^3.0.0, mime-types@^3.0.1:
   version "3.0.1"
@@ -3144,11 +3095,6 @@ proxy-addr@^2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
-  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pstree.remy@^1.1.8:
   version "1.1.8"


### PR DESCRIPTION
Axios introduserer sårbarheter som krever oppdateringer. Native fetch dekker behovene våre for enkle HTTP-kall og fjerner en unødvendig avhengighet.

- Erstatter axios med native fetch