### PR TITLE
Vi ønsker å vise fødselsdato istedenfor fnr i utbetalingstabell

### DIFF
--- a/src/server/components/serializers/UtbetalingerSerializer.tsx
+++ b/src/server/components/serializers/UtbetalingerSerializer.tsx
@@ -41,19 +41,12 @@ const YtelseTypeText: Record<YtelseType, string> = {
   [YtelseType.SMÅBARNSTILLEGG]: 'Småbarnstillegg',
 };
 
-const barnetrygdTekst = (fnr: string, ytelseType: YtelseType) => {
+const barnetrygdTekst = (fødselsdato: string, ytelseType: YtelseType) => {
   if (ytelseType === YtelseType.ORDINÆR_BARNETRYGD) {
-    return `Barn ${formatterFnr(fnr)}`;
+    return `Barn ${fødselsdato}`;
   } else {
     return YtelseTypeText[ytelseType];
   }
-};
-
-const formatterFnr = (fnr: string) => {
-  if (fnr.length === 11) {
-    return `${fnr.substring(0, 6)} ${fnr.substring(6)}`;
-  }
-  return fnr;
 };
 
 const ZebraStripedTable = styled.table`
@@ -140,7 +133,7 @@ export const UtbetalingerSerializer = (props: UtbetalingerProps) => {
                   key={mndÅr + '-' + index}
                 >
                   <StyledTableData align="left">
-                    {barnetrygdTekst(utbetalingEØS.fnr, utbetalingEØS.ytelseType)}
+                    {barnetrygdTekst(utbetalingEØS.fødselsdato, utbetalingEØS.ytelseType)}
                   </StyledTableData>
                   <StyledTableData align="left">{mndÅr}</StyledTableData>
                   <StyledTableData align="right">

--- a/src/typer/utbetalingerEøs.ts
+++ b/src/typer/utbetalingerEøs.ts
@@ -14,7 +14,7 @@ export interface UtbetalingMndEøsOppsummering {
 }
 
 export interface UtbetalingEøs {
-  fnr: string;
+  fødselsdato: string;
   ytelseType: YtelseType;
   satsINorge: number;
   utbetaltFraAnnetLand: UtbetaltFraAnnetLand | null;


### PR DESCRIPTION
### 📮 Favro: Nav-29021

### 💰 Hva skal gjøres, og hvorfor?

Vi ønsker å vise fødselsdato istedenfor FNR i utbetalingstabellen.
Krever at vi nå slår opp faktiske fødselsdato i person objektet til aktøren.

Se [familie-ba-sak pr](https://github.com/navikt/familie-ba-sak/pull/6258) for endringer der.

<img width="653" height="570" alt="Screenshot 2026-05-10 at 15 07 29" src="https://github.com/user-attachments/assets/a16ec8a6-de64-4a0a-ab52-0b12c6b8db3e" />
