### PR TITLE
Blankett - vise regelverk

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,8 +24,6 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      'react-hooks/static-components': 'warn', // Use recommended instead when warning is fixed
-      'react-hooks/immutability': 'warn', // Use recommended instead when warning is fixed
     },
     settings: {
       react: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,11 @@ import tseslint from 'typescript-eslint';
 import react from 'eslint-plugin-react';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 
+const reactHooksOptionalWarnRules = {
+  ...(reactHooks.rules['static-components'] ? { 'react-hooks/static-components': 'warn' } : {}),
+  ...(reactHooks.rules.immutability ? { 'react-hooks/immutability': 'warn' } : {}),
+};
+
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -20,6 +25,7 @@ export default tseslint.config(
     plugins: { 'react-hooks': reactHooks },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      ...reactHooksOptionalWarnRules,
       'react/no-unescaped-entities': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-vars': 'off',

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -92,6 +92,7 @@ export const Dokument = (dokumentProps: DokumentProps) => {
                   barnId={vurdering.barnId}
                   tidligereVedtaksperioder={tidligereVedtaksperioder}
                   stønadstype={stønadstype}
+                  erRegelendring2026={dokumentData.behandling.erRegelendring2026}
                 />
                 <Vilkårsvurdering vurdering={vurdering} />
                 {beregnetSamværForVilkårsvurdering && (

--- a/src/server/blankett/components/Dokument.tsx
+++ b/src/server/blankett/components/Dokument.tsx
@@ -93,6 +93,9 @@ export const Dokument = (dokumentProps: DokumentProps) => {
                   tidligereVedtaksperioder={tidligereVedtaksperioder}
                   stønadstype={stønadstype}
                   erRegelendring2026={dokumentData.behandling.erRegelendring2026}
+                  featureToggleRegelendringer2026={
+                    dokumentData.behandling.featureToggleRegelendringer2026
+                  }
                 />
                 <Vilkårsvurdering vurdering={vurdering} />
                 {beregnetSamværForVilkårsvurdering && (

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -25,6 +25,7 @@ export interface RegistergrunnlagForVilkårProps {
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
   stønadstype: EStønadType;
   erRegelendring2026: boolean;
+  featureToggleRegelendringer2026: boolean;
 }
 
 export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProps> = ({
@@ -34,6 +35,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
   tidligereVedtaksperioder,
   stønadstype,
   erRegelendring2026,
+  featureToggleRegelendringer2026,
 }) => {
   switch (vilkårgruppe) {
     case VilkårGruppe.MEDLEMSKAP:
@@ -63,6 +65,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
         <TidligereHistorikk
           tidligereVedtaksperioder={tidligereVedtaksperioder}
           erRegelendring2026={erRegelendring2026}
+          featureToggleRegelendringer2026={featureToggleRegelendringer2026}
           stønadstype={stønadstype}
         />
       );

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -63,6 +63,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
         <TidligereHistorikk
           tidligereVedtaksperioder={tidligereVedtaksperioder}
           erRegelendring2026={erRegelendring2026}
+          stønadstype={stønadstype}
         />
       );
     case Vilkår.INNTEKT:

--- a/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
+++ b/src/server/blankett/components/RegistergrunnlagForVilkår.tsx
@@ -24,6 +24,7 @@ export interface RegistergrunnlagForVilkårProps {
   barnId?: string;
   tidligereVedtaksperioder?: ITidligereVedtaksperioder;
   stønadstype: EStønadType;
+  erRegelendring2026: boolean;
 }
 
 export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProps> = ({
@@ -32,6 +33,7 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
   barnId,
   tidligereVedtaksperioder,
   stønadstype,
+  erRegelendring2026,
 }) => {
   switch (vilkårgruppe) {
     case VilkårGruppe.MEDLEMSKAP:
@@ -57,7 +59,12 @@ export const RegistergrunnlagForVilkår: React.FC<RegistergrunnlagForVilkårProp
     case VilkårGruppe.NYTT_BARN_SAMME_PARTNER:
       return <NyttBarnSammePartner barnMedSamvær={grunnlag.barnMedSamvær} />;
     case Vilkår.TIDLIGERE_VEDTAKSPERIODER:
-      return <TidligereHistorikk tidligereVedtaksperioder={tidligereVedtaksperioder} />;
+      return (
+        <TidligereHistorikk
+          tidligereVedtaksperioder={tidligereVedtaksperioder}
+          erRegelendring2026={erRegelendring2026}
+        />
+      );
     case Vilkår.INNTEKT:
     case VilkårGruppe.RETT_TIL_OVERGANGSSTØNAD:
       if (stønadstype !== StønadType.OVERGANGSSTØNAD) {

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -22,7 +22,9 @@ export const TidligereHistorikk: React.FC<{
       {stønadstype === EStønadType.OVERGANGSSTØNAD && (
         <div>
           <strong>Regelverk: </strong>
-          {erRegelendring2026 ? 'Nytt regelverk (fra 01.07.2026)' : 'Gammelt regelverk'}
+          {erRegelendring2026
+            ? 'Nytt regelverk (fra 01.07.2026)'
+            : 'Gammelt regelverk (før 1. juli 2026)'}
         </div>
       )}
       <h3 className={'blankett'}>Registerdata</h3>

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -11,15 +11,21 @@ import { formaterIsoDato, mapBooleanTilString } from '../../utils/util';
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
   erRegelendring2026: boolean;
+  featureToggleRegelendringer2026: boolean;
   stønadstype: EStønadType;
-}> = ({ tidligereVedtaksperioder, erRegelendring2026, stønadstype }) => {
+}> = ({
+  tidligereVedtaksperioder,
+  erRegelendring2026,
+  featureToggleRegelendringer2026,
+  stønadstype,
+}) => {
   const periodeHistorikkOvergangsstønad =
     tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad;
   const periodeHistorikkBarnetilsyn = tidligereVedtaksperioder?.sak?.periodeHistorikkBarnetilsyn;
 
   return (
     <>
-      {stønadstype === EStønadType.OVERGANGSSTØNAD && (
+      {stønadstype === EStønadType.OVERGANGSSTØNAD && featureToggleRegelendringer2026 && (
         <div>
           <strong>Regelverk: </strong>
           {erRegelendring2026

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -23,8 +23,8 @@ export const TidligereHistorikk: React.FC<{
         <div>
           <strong>Regelverk: </strong>
           {erRegelendring2026
-            ? 'Nytt regelverk (fra 01.07.2026)'
-            : 'Gammelt regelverk (før 1. juli 2026)'}
+            ? 'Nytt regelverk fra 01.07.2026'
+            : 'Gammelt regelverk før 01.07.2026'}
         </div>
       )}
       <h3 className={'blankett'}>Registerdata</h3>

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -10,13 +10,18 @@ import { formaterIsoDato, mapBooleanTilString } from '../../utils/util';
 
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
-}> = ({ tidligereVedtaksperioder }) => {
+  erRegelendring2026: boolean;
+}> = ({ tidligereVedtaksperioder, erRegelendring2026 }) => {
   const periodeHistorikkOvergangsstønad =
     tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad;
   const periodeHistorikkBarnetilsyn = tidligereVedtaksperioder?.sak?.periodeHistorikkBarnetilsyn;
 
   return (
     <>
+      <div>
+        <strong>Regelverk: </strong>
+        {erRegelendring2026 ? 'Nytt regelverk (fra 01.07.2026)' : 'Gammelt regelverk'}
+      </div>
       <h3 className={'blankett'}>Registerdata</h3>
       <p>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd?</p>
       <h3 className={'blankett'}>Overgangsstønad</h3>

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -5,23 +5,26 @@ import type {
   ITidligereVedtaksperioder,
   OverlappMedOvergangsstønad,
 } from '../../../typer/dokumentApiBlankett';
-import { EPeriodetype, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
+import { EPeriodetype, EStønadType, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
 import { formaterIsoDato, mapBooleanTilString } from '../../utils/util';
 
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
   erRegelendring2026: boolean;
-}> = ({ tidligereVedtaksperioder, erRegelendring2026 }) => {
+  stønadstype: EStønadType;
+}> = ({ tidligereVedtaksperioder, erRegelendring2026, stønadstype }) => {
   const periodeHistorikkOvergangsstønad =
     tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad;
   const periodeHistorikkBarnetilsyn = tidligereVedtaksperioder?.sak?.periodeHistorikkBarnetilsyn;
 
   return (
     <>
-      <div>
-        <strong>Regelverk: </strong>
-        {erRegelendring2026 ? 'Nytt regelverk (fra 01.07.2026)' : 'Gammelt regelverk'}
-      </div>
+      {stønadstype === EStønadType.OVERGANGSSTØNAD && (
+        <div>
+          <strong>Regelverk: </strong>
+          {erRegelendring2026 ? 'Nytt regelverk (fra 01.07.2026)' : 'Gammelt regelverk'}
+        </div>
+      )}
       <h3 className={'blankett'}>Registerdata</h3>
       <p>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd?</p>
       <h3 className={'blankett'}>Overgangsstønad</h3>

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -18,6 +18,7 @@ export interface IBehandling {
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
   registeropplysningerOpprettetDato: string;
   erRegelendring2026: boolean;
+  featureToggleRegelendringer2026: boolean;
 }
 
 export interface ITidligereVedtaksperioder {

--- a/src/typer/dokumentApiBlankett.ts
+++ b/src/typer/dokumentApiBlankett.ts
@@ -17,6 +17,7 @@ export interface IBehandling {
   harKontantstøttePerioder: boolean;
   kontantstøttePerioderFraKs: IKontantstøttePerioder[];
   registeropplysningerOpprettetDato: string;
+  erRegelendring2026: boolean;
 }
 
 export interface ITidligereVedtaksperioder {


### PR DESCRIPTION
- Bruker flagget 'erRegelendring2026' og skriver hvilket regelverk som er brukt i behandling.
- Sletter gamle eslint regler som gjør at eslint feiler
- Tar i bruk toggle fra ef-sak siden vi ikke skal vise det nye feltet før 1. juli

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29586)

<img width="1628" height="1152" alt="image" src="https://github.com/user-attachments/assets/eb1a6ef0-2b71-443d-8ff2-99f07198ec22" />
