### PR TITLE
NAV-29864: Legg til valgfelt-mulighet for annen forelders aktivitet IKKE_AKTUELT

### DIFF
--- a/src/baks/formateringsvalg.ts
+++ b/src/baks/formateringsvalg.ts
@@ -291,6 +291,7 @@ export const annenForeldersAktivitetValg = (
     case Aktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET:
       return ValgfeltMuligheter.EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET;
     case Aktivitet.IKKE_AKTUELT:
+      return ValgfeltMuligheter.EOS_ANNEN_FORELDER_IKKE_AKTUELT;
     default:
       throw new Feil(
         `Ingen valg for annen forelders aktivitet="${aktivitet}" ved bruk av

--- a/src/baks/typer.ts
+++ b/src/baks/typer.ts
@@ -117,6 +117,7 @@ export enum ValgfeltMuligheter {
   EOS_ANNEN_FORELDER_MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarPensjonFraNavUnderOppholdIUtlandet',
   EOS_ANNEN_FORELDER_MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarUtbetalingFraNavUnderOppholdIUtlandet',
   EOS_ANNEN_FORELDER_MOTTAR_UFOERETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'eosAnnenForelderMottarUfoeretrygdFraNavUnderOppholdIUtlandet',
+  EOS_ANNEN_FORELDER_IKKE_AKTUELT = 'eosAnnenForelderIkkeAktuelt',
 }
 
 export interface SpanBlock {


### PR DESCRIPTION
### 📮 Favro
NAV-29864

### 💰 Hva skal gjøres, og hvorfor?
EØS-begrunnelser som bruker formuleringen 'annen forelders aktivitet' feiler i dag med 400 når annen forelders aktivitet er `IKKE_AKTUELT` – som er det saksbehandler registrerer ved «Nasjonal rett – differanseberegning». Dermed er Bosmann-begrunnelsestekstene utilgjengelige på vedtakssiden i ba-sak, hvor feilen vises som «Begrunnelsen … passer ikke vedtaksperioden». De tre aleneansvar-variantene fungerer fordi de ikke bruker denne formuleringen.

- Lagt til `EOS_ANNEN_FORELDER_IKKE_AKTUELT = 'eosAnnenForelderIkkeAktuelt'` i `ValgfeltMuligheter`
- `annenForeldersAktivitetValg` mapper nå `Aktivitet.IKKE_AKTUELT` til denne valgmuligheten i stedet for å kaste 400