### PR TITLE
Bruk null-sikker datoformattering i blankett-komponenter

### DIFF
--- a/src/server/blankett/components/InntektGrunnlag.tsx
+++ b/src/server/blankett/components/InntektGrunnlag.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formaterIsoDato } from '../../utils/util';
+import { formaterNullableIsoDato } from '../../utils/util';
 import type {
   ITidligereVedtaksperioder,
   IGrunnlagsdataSistePeriodeOvergangsstønad,
@@ -45,7 +45,8 @@ export const InntektGrunnlag: React.FC<{
             (periode: IGrunnlagsdataSistePeriodeOvergangsstønad, index) => (
               <tr key={index}>
                 <td>
-                  {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
+                  {formaterNullableIsoDato(periode.fom) || '-'} -{' '}
+                  {formaterNullableIsoDato(periode.tom) || '-'}
                 </td>
                 <td>{periodetypeTilTekst[periode.vedtaksperiodeType]}</td>
                 {stønadstype === StønadType.BARNETILSYN ? (

--- a/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/blankett/components/InnvilgetBarnetilsyn.tsx
@@ -4,7 +4,11 @@ import {
   IKontantstøttePerioder,
   ISøknadsdatoer,
 } from '../../../typer/dokumentApiBlankett';
-import { formaterIsoDato, mapBooleanTilJaNei, parseOgFormaterÅrMåned } from '../../utils/util';
+import {
+  formaterNullableIsoDato,
+  mapBooleanTilJaNei,
+  parseOgFormaterÅrMåned,
+} from '../../utils/util';
 import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 
 export const InnvilgetBarnetilsyn: React.FC<{
@@ -35,15 +39,15 @@ export const InnvilgetBarnetilsyn: React.FC<{
       return (
         <p>
           Bruker har verken fått eller får kontantstøtte (oppdatert{' '}
-          {formaterIsoDato(registeropplysningerOpprettetDato)})
+          {formaterNullableIsoDato(registeropplysningerOpprettetDato) || '-'})
         </p>
       );
     }
     if (kontantstøttePerioderFraGrunnlagsdata.length > 0) {
       return (
         <p>
-          Brukers kontantstøtteperioder (hentet {formaterIsoDato(registeropplysningerOpprettetDato)}
-          )
+          Brukers kontantstøtteperioder (hentet{' '}
+          {formaterNullableIsoDato(registeropplysningerOpprettetDato) || '-'})
         </p>
       );
     }

--- a/src/server/blankett/components/KlageBehandling.tsx
+++ b/src/server/blankett/components/KlageBehandling.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { formaterIsoDato, formaterIsoDatoTid } from '../../utils/util';
+import { formaterIsoDatoTid, formaterNullableIsoDato } from '../../utils/util';
 import {
   behandlingResultatTilTekst,
   EFormVilkår,
@@ -54,7 +54,7 @@ export const KlageBehandling: React.FC<{ behandling: IKlageBehandling }> = ({ be
         <strong>Saksnummer:</strong> {behandling.eksternFagsakId}
       </div>
       <div>
-        <strong>Klage mottatt:</strong> {formaterIsoDato(behandling.klageMottatt)}
+        <strong>Klage mottatt:</strong> {formaterNullableIsoDato(behandling.klageMottatt) || '-'}
       </div>
       <div>
         <strong>Resultat:</strong> {behandlingResultatTilTekst[behandling.resultat]}

--- a/src/server/blankett/components/TidligereHistorikk.tsx
+++ b/src/server/blankett/components/TidligereHistorikk.tsx
@@ -6,7 +6,7 @@ import type {
   OverlappMedOvergangsstønad,
 } from '../../../typer/dokumentApiBlankett';
 import { EPeriodetype, EStønadType, periodetypeTilTekst } from '../../../typer/dokumentApiBlankett';
-import { formaterIsoDato, mapBooleanTilString } from '../../utils/util';
+import { formaterNullableIsoDato, mapBooleanTilString } from '../../utils/util';
 import { Regelendring2026Visning } from './Regelendring2026Visning';
 
 export const TidligereHistorikk: React.FC<{
@@ -92,7 +92,8 @@ const TidligereHistorikkOvergangsstønadTabell: React.FC<{
         return (
           <tr key={periode.fom + index}>
             <td>
-              {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
+              {formaterNullableIsoDato(periode.fom) || '-'} -{' '}
+              {formaterNullableIsoDato(periode.tom) || '-'}
             </td>
             <td>{periodetypeTilTekst[periode.vedtaksperiodeType] || ''}</td>
             <td>{periode.antallMåneder}</td>
@@ -123,7 +124,8 @@ const TidligereHistorikkBarnetilsynTabell: React.FC<{
         return (
           <tr key={periode.fom + index}>
             <td>
-              {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
+              {formaterNullableIsoDato(periode.fom) || '-'} -{' '}
+              {formaterNullableIsoDato(periode.tom) || '-'}
             </td>
             <td>
               {overlappMedOvergangsstønadTilTekst[periode.overlapperMedOvergangsstønad || '']}


### PR DESCRIPTION
parseISO() fra date-fns kaster 'Cannot read properties of undefined (reading match)' når input er undefined. Fire steder i blankett- komponentene kalte formaterIsoDato() direkte på felter som kan mangle (periode.fom/tom, klageMottatt, registeropplysningerOpprettetDato), og feilet dermed PDF-generering med 500 Internal Server Error.

Bytter til den eksisterende null-sikre varianten formaterNullableIsoDato() med '-' som fallback-visning, i tråd med etablert mønster ellers i kodebasen (Sivilstand.tsx, AnnenForelder.tsx m.fl.).