### PR TITLE
fix(nais): add team_logs to observability logging destinations

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -63,6 +63,7 @@ spec:
       destinations:
         - id: elastic
         - id: loki
+        - id: team_logs
     autoInstrumentation:
       enabled: true
       runtime: nodejs

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -63,6 +63,7 @@ spec:
       destinations:
         - id: elastic
         - id: loki
+        - id: team_logs
     autoInstrumentation:
       enabled: true
       runtime: nodejs


### PR DESCRIPTION
Replaces the deprecated top-level spec.secureLogs field, which is no longer part of the Application CRD and causes a strict decoding error on deploy. Secure logs are now enabled via observability.logging.destinations with id: team_logs (see https://doc.nais.io/observability/logging/reference/destinations/).